### PR TITLE
Fix master build failure and other quick issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: [3.7, 3.9]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,10 +70,9 @@ jobs:
 
     - name: Install pip dependencies
       run: |
-        pip install numpy  # pygsl doesn't install without this
         pip install --use-deprecated=legacy-resolver -r requirements.txt
         pip install --use-deprecated=legacy-resolver -r doc/requirements.txt
-        pip install --use-deprecated=legacy-resolver -e .[sphfunc]
+        pip install --use-deprecated=legacy-resolver -e .
 
     - name: Build sphinx docs
       run: sphinx-build -W -b html doc/ doc/_build/html

--- a/cora/signal/corr.py
+++ b/cora/signal/corr.py
@@ -993,6 +993,7 @@ def _pl(l, x):
 @np.vectorize
 def _integrate(r, l, psfunc):
 
+    from scipy.integrate import quad
     from ..util import sphfunc
 
     def _integrand_linear(k, r, l, psfunc):

--- a/cora/util/cosmology.py
+++ b/cora/util/cosmology.py
@@ -324,7 +324,7 @@ def _intf_0_z(f, z):
 
     # Wrap and unwrap in case we are operating on a scalar
     if not isinstance(z, np.ndarray):
-        z = np.array([z])
+        z = np.array([z], dtype=np.float64)
         return _intf_0_z(f, z)[0]
 
     # Write the y' function for the ODE solver

--- a/cora/util/cosmology.py
+++ b/cora/util/cosmology.py
@@ -302,7 +302,7 @@ class Cosmology(object):
         elif self.units == "si":
             return 1.0
 
-        raise Exception("Units not known")
+        raise RuntimeError("Units not known")
 
     @property
     def _unit_time(self):
@@ -314,7 +314,7 @@ class Cosmology(object):
         elif self.units == "si":
             return 1.0
 
-        raise Exception("Units not known")
+        raise RuntimeError("Units not known")
 
 
 def _intf_0_z(f, z):

--- a/cora/util/sphfunc.py
+++ b/cora/util/sphfunc.py
@@ -7,8 +7,7 @@ available in `scipy` they tend to be inaccurate at large values of `l`.
 
 
 import numpy as np
-
-import pygsl.testing.sf as sf
+import scipy.special as ss
 
 
 def jl(l, z):
@@ -47,7 +46,7 @@ def jl(l, z):
     jla[zza] = 0.0
     jla[lza] = _jl_approx_lowz(la[lza], za[lza])
     jla[hza] = _jl_approx_highz(la[hza], za[hza])
-    jla[gza] = _jl_gsl(la[gza], za[gza])
+    jla[gza] = ss.spherical_jn(la[gza], za[gza])
 
     if isinstance(lt, np.ndarray) or isinstance(zt, np.ndarray):
         return jla

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     packages=find_packages(),
     ext_modules=cythonize([cs_ext, bm_ext, cr_ext]),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=requires,
     package_data={
         "cora.signal": ["data/ps_z1.5.dat", "data/corr_z1.5.dat"],

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
     ext_modules=[cs_ext, bm_ext, cr_ext],
     python_requires=">=3.6",
     install_requires=requires,
-    extras_require={"sphfunc": ["pygsl"]},
     package_data={
         "cora.signal": ["data/ps_z1.5.dat", "data/corr_z1.5.dat"],
         "cora.foreground": ["data/skydata.npz", "data/combinedps.dat"],

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 import os
-import warnings
 
 from setuptools import setup, Extension, find_packages
 from distutils import sysconfig
+
+from Cython.Build import cythonize
 
 import re
 
@@ -21,27 +22,10 @@ else:
     args = ["-fopenmp"]
 
 
-# Cython extensions
-try:
-    from Cython.Distutils import build_ext
-
-    HAVE_CYTHON = True
-except ImportError as e:
-    warnings.warn("Cython not installed.")
-    from distutils.command import build_ext
-
-    HAVE_CYTHON = False
-
-
-def cython_file(filename):
-    return filename + (".pyx" if HAVE_CYTHON else ".c")
-
-
 # Cubic spline extension
-# args = to_native(args)  # TODO: Python 3
 cs_ext = Extension(
     "cora.util.cubicspline",
-    [cython_file("cora/util/cubicspline")],
+    ["cora/util/cubicspline.pyx"],
     include_dirs=[np.get_include()],
     extra_compile_args=args,
     extra_link_args=args,
@@ -50,7 +34,7 @@ cs_ext = Extension(
 # Bi-linear map extension
 bm_ext = Extension(
     "cora.util.bilinearmap",
-    [cython_file("cora/util/bilinearmap")],
+    ["cora/util/bilinearmap.pyx"],
     include_dirs=[np.get_include()],
     extra_compile_args=args,
     extra_link_args=args,
@@ -59,7 +43,7 @@ bm_ext = Extension(
 # coord extension
 cr_ext = Extension(
     "cora.util.coord",
-    [cython_file("cora/util/coord")],
+    ["cora/util/coord.pyx"],
     include_dirs=[np.get_include()],
     extra_compile_args=args,
     extra_link_args=args,
@@ -77,9 +61,9 @@ with open("README.rst", "r") as fh:
 setup(
     name="cora",
     version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass({"build_ext": build_ext}),
+    cmdclass=versioneer.get_cmdclass(),
     packages=find_packages(),
-    ext_modules=[cs_ext, bm_ext, cr_ext],
+    ext_modules=cythonize([cs_ext, bm_ext, cr_ext]),
     python_requires=">=3.6",
     install_requires=requires,
     package_data={


### PR DESCRIPTION
This fixes the pygsl related CI build failure on master, tidies up the Cython building in setup.py
and modernizes the cosmology class.

- fix(sphfunc): change to use scipy spherical Bessel routines
- fix(corr): missing import broke correlation function calculation
- fix(setup): require Cython as a dependency
- refactor(cosmology): modernize the `Cosmology` class to use dataclasses
- fix(cosmology): incorrect calculations when exact integer redshifts are input
- refactor(cosmology): use more appropriate exception types
