### PR TITLE
fix(coord): ensure array are C-ordered contiguous, before reshaping

### DIFF
--- a/cora/util/coord.pyx
+++ b/cora/util/coord.pyx
@@ -60,7 +60,8 @@ def sph_to_cart(sph_coords):
     nd = sph_coords.shape[-1]
 
     # Make sure we are dealing with double precision types
-    sph_view = sph_coords.astype(np.float64, copy=False).reshape(-1, nd)
+    sph_coords = np.ascontiguousarray(sph_coords).astype(np.float64, copy=False)
+    sph_view = sph_coords.reshape(-1, nd)
 
     # Create an array of the correct size for the output.
     cart_coords = np.empty(sph_coords.shape[:-1] + (3,), dtype=np.float64)
@@ -190,8 +191,7 @@ def thetaphi_plane_cart(sph_coords):
     if not isinstance(sph_coords, np.ndarray) or sph_coords.shape[-1] != 2:
         raise ValueError("Argument must be a numpy array with last axis of length 2.")
 
-    #sph_coords = np.ascontiguousarray(sph_coords).astype(np.float64, copy=False)
-    #sph_coords = np.ascontiguousarray(sph_coords).astype(np.float64, copy=False)
+    sph_coords = np.ascontiguousarray(sph_coords).astype(np.float64, copy=False)
     sph_view = sph_coords.reshape(-1, 2)
 
     # Create an array of the correct size for the output.


### PR DESCRIPTION
`reshape()` needs to know whether `ndarrays` are C-contiguous or F-contiguous. On default, it assumes C-contiguous:
https://numpy.org/doc/stable/reference/generated/numpy.reshape.html?highlight=reshape

Recently, there have been crashes in the pipeline related to the calculation of beamforms. It is hypothesised that the crashes are related to this PR: https://github.com/radiocosmology/draco/pull/131/files


```
  File "/project/6003614/anja/code/caput/caput/scripts/runner.py", line 139, in run                                                                            
    P.run()                                                                                                                                                    
  File "/project/6003614/anja/code/caput/caput/pipeline.py", line 603, in run                                                                                  
    out = task._pipeline_next()                                                                                                                                
  File "/project/6003614/anja/code/caput/caput/pipeline.py", line 1038, in _pipeline_next                                                                      
    out = self.next(*args)                                                                                                                                     
  File "/project/6003614/anja/code/draco/draco/core/task.py", line 319, in next                                                                                
    output = self.process(*input)                                                                                                                              
  File "/project/6003614/anja/code/draco/draco/analysis/beamform.py", line 722, in process                                                                     
    return super(BeamFormCat, self).process()                                                                                                                  
  File "/project/6003614/anja/code/draco/draco/analysis/beamform.py", line 270, in process                                                                     
    primary_beam = self._beamfunc(pol_str, dec, ha_array)                                                                                                      
  File "/project/6003614/anja/code/draco/draco/analysis/beamform.py", line 487, in _beamfunc                                                                   
    bii = self.telescope.beam(self.map_pol_feed[pol[0]], freq, angpos)                                                                                         
  File "/project/6003614/anja/code/ch-pipeline/ch_pipeline/core/telescope.py", line 452, in beam                                                               
    beam = cylbeam.beam_x(                                                                                                                                     
  File "/project/6003614/anja/code/driftscan/drift/telescope/cylbeam.py", line 211, in beam_x                                                                  
    pvec = polpattern(angpos, xhat)                                                                                                                            
  File "/project/6003614/anja/code/driftscan/drift/telescope/cylbeam.py", line 30, in polpattern
    thatp, phatp = coord.thetaphi_plane_cart(angpos)
  File "cora/util/coord.pyx", line 195, in cora.util.coord.thetaphi_plane_cart
  File "stringsource", line 658, in View.MemoryView.memoryview_cwrapper
  File "stringsource", line 349, in View.MemoryView.memoryview.__cinit__
ValueError: ndarray is not C-contiguous 
```

`reshape` expected a C-ordered contiguous array, and was instead getting F-contiguous arrays, within various functions in `cora.util.coord`. This could have happened because, F-ordered contiguous arrays are the results of Transposes with `.T` of C-contiguous arrays.

These changes ensure the arrays are C-ordered contiguous, using https://numpy.org/doc/stable/reference/generated/numpy.ascontiguousarray.html?highlight=ascontiguousarray#numpy.ascontiguousarray before they are passed to `reshape`.