### PR TITLE
build: build using the oldest supported numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'Cython', 'numpy>=1.16']
+requires = ['setuptools', 'wheel', 'Cython', 'oldest-supported-numpy']


### PR DESCRIPTION
Binaries compiled with old Numpy versions are ABI compatible with
newer Numpy versions, but not vice-versa.

To avoid running issues into on cedar, we should build using the oldest
compatible numpy version. We can then run packages using whatever newer
Numpy version we want.

Conversation here: https://github.com/radiocosmology/draco/pull/145