### PR TITLE
Numpy 2.0 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: "3.12"
 
     - name: Install linting requirements
-      run: pip install -e .[lint]
+      run: pip install black
 
     - name: Check code with black
       run: black --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "setuptools-git-versioning",
     "cython",
-    "oldest-supported-numpy",
+    "numpy>=2.0.0rc1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -26,7 +26,7 @@ dependencies = [
     "cython",
     "h5py",
     "healpy>=1.15",
-    "numpy>=1.7,<2",
+    "numpy>=1.24",
     "scipy>=0.10",
     "skyfield",
 ]


### PR DESCRIPTION
Update build requirement to `numpy >= 2.0.0.rc1`, which is the first release candidate of numpy 2.0. Also, bump the minimum supported numpy based on numpy support schedule [here](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule).

Question: are there any other tests that we should include?