### PR TITLE
Parallelize the LSS pipeline

### DIFF
--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -5,6 +5,8 @@ import scipy.integrate as si
 import scipy.special as ss
 from scipy.fftpack import dct
 
+from caput import mpiarray
+
 import hankl
 import hankel
 import pyfftlog
@@ -329,9 +331,6 @@ def corr_to_clarray(
     M = q * lmax
     mu, w, wsum = ss.roots_legendre(M, mu=True)
 
-    xlen = xarray.size
-    corr_array = np.zeros((M, xlen, xlen))
-
     # If xromb > 0 we need to integrate over the radial bin width, start by modifying
     # the array of distances to add extra points over which we'll integrate
     #
@@ -359,12 +358,15 @@ def corr_to_clarray(
     else:
         xa = xarray
 
-    # Split the set of theta values to fill into groups of length ~50 and process each,
-    # this is helps reduce memory usage which otherwise we be massively inflated by the
-    # extra points we integrate over
-    for msec in np.array_split(np.arange(M), M // 50):
+    xlen = xarray.size
+    corr_array = mpiarray.zeros((M, xlen, xlen), axis=0)
+    clo = corr_array.local_offset[0]
+    _len = corr_array.local_array.shape[0]
 
-        rc = coord.cosine_rule(mu[msec], xa, xa)
+    # Split thetas into ~length 50 chunks, otherwise memory will blow up
+    for msec in np.array_split(np.arange(_len), _len // 50):
+        # Index into the global index in mu
+        rc = coord.cosine_rule(mu[clo + msec], xa, xa)
         corr1 = corr(rc)
 
         # If xromb then we need to integrate over the redshift bins which we do using
@@ -374,15 +376,21 @@ def corr_to_clarray(
             corr1 = np.matmul(corr1, x_w).reshape(-1, xlen, xint, xlen)
             corr1 = np.matmul(corr1.transpose(0, 1, 3, 2), x_w)
 
-        corr_array[msec, :, :] = corr1
+        corr_array.local_array[msec] = corr1
 
+    # Perform the dot product split over ranks for
+    # memory and time
     lm = legendre_array(lmax, mu)
-    lm *= w * 4.0 * np.pi / wsum
+    lm *= w[np.newaxis] * 4.0 * np.pi / wsum
 
-    clxx = np.dot(lm, corr_array.reshape(M, -1))
-    clxx = clxx.reshape(lmax + 1, xlen, xlen)
+    # Reshape and properly distribute the array to
+    # perform the dot product
+    corr_array = corr_array.reshape(None, -1).redistribute(axis=1)
 
-    return clxx
+    clxx = np.dot(lm, corr_array.local_array)
+    clxx = mpiarray.MPIArray.wrap(clxx, axis=1).redistribute(axis=0)
+
+    return clxx.reshape(None, xlen, xlen)
 
 
 def ps_to_aps_flat(

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -224,7 +224,7 @@ def laplacian(maps: np.ndarray, x: np.ndarray) -> np.ndarray:
     return d2
 
 
-def gradient(maps: np.ndarray, x: np.ndarray) -> np.ndarray:
+def gradient(maps: np.ndarray, x: np.ndarray, grad0: bool = True) -> np.ndarray:
     """Take the gradient of a set of maps.
 
     Parameters
@@ -233,6 +233,10 @@ def gradient(maps: np.ndarray, x: np.ndarray) -> np.ndarray:
         An 2D array of maps. First axis is the x coord, second is Healpix pixels.
     x
         The coordinate along the first axis. This axis need not be uniform.
+    grad0
+        If True, compute the gradient along axis 0. Otherwise, output `grad[0]`
+        will not be computed. This is useful if `maps` is distributed.
+        Default is True.
 
     Returns
     -------
@@ -253,8 +257,9 @@ def gradient(maps: np.ndarray, x: np.ndarray) -> np.ndarray:
         # NOTE: the zeroth component doesn't yet contain dr
         grad[1:, i] = healpy.alm2map_der1(alm, nside)[1:] / x[i]
 
-    # TODO: try and do this in place so as not to balloon the memory
-    grad[0] = np.gradient(maps, x, axis=0)
+    if grad0:
+        # TODO: try and do this in place so as not to balloon the memory
+        grad[0] = np.gradient(maps, x, axis=0)
 
     return grad
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ maintainers = [
 dynamic = ["readme", "version"]
 requires-python = ">=3.9"
 dependencies = [
+    "caput @ git+https://github.com/radiocosmology/caput.git",
     "click",
     "cython",
     "h5py",


### PR DESCRIPTION
Ongoing PR to parallelize and speed up the LSS tasks. 

Most tasks are already quite fast - the only bottleneck is `signal.corrfunc.corr_to_clarray`, with the main bottleneck there being the calls to `util.cubicspline.SinhInterpolator`. The interpolator is already openmp parallel, so adding MPI parallelization requires using multiple nodes to get any speed-up. 