### PR TITLE
Fix LSS MPI bugs

### DIFF
--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -420,6 +420,7 @@ class GenerateBiasedFieldBase(task.SingleTask):
         z = f.redshift if self.lightcone else self.redshift * np.ones_like(f.chi)
         D = f.cosmology.growth_factor(z) / f.cosmology.growth_factor(0)
 
+        f.redistribute("chi")
         fd = f.delta[:].local_array
 
         # Apply any first order bias
@@ -734,13 +735,17 @@ class LinearDynamics(DynamicsBase):
         self._validate_fields(initial_field, biased_field)
         c, _, __, chi, za = self._get_props(biased_field)
 
+        # Distribute over the pixel axis for derivatives
+        initial_field.redistribute("pixel")
+        biased_field.redistribute("pixel")
+
         # Create the final field container
         final_field = BiasedLSS(axes_from=biased_field, attrs_from=biased_field)
+        final_field.redistribute("pixel")
 
         fdelta = final_field.delta[:].local_array
         idelta = initial_field.delta[:].local_array
         iphi = initial_field.phi[:].local_array
-        lsel = final_field.delta[:].local_bounds
 
         # Get growth factor:
         D = c.growth_factor(za) / c.growth_factor(0)
@@ -750,14 +755,16 @@ class LinearDynamics(DynamicsBase):
 
         # Add in standard linear term
 
-        fdelta[:] += D[lsel, np.newaxis] * idelta
+        fdelta[:] += D[:, np.newaxis] * idelta
 
         if self.redshift_space:
             fr = c.growth_rate(za)
-            vterm = lssutil.diff2(iphi, chi[lsel], axis=0)
-            vterm *= -(D * fr)[lsel, np.newaxis]
+            vterm = lssutil.diff2(iphi, chi[:], axis=0)
+            vterm *= -(D * fr)[:, np.newaxis]
 
             fdelta[:] += vterm
+
+        final_field.redistribute("chi")
 
         return final_field
 


### PR DESCRIPTION
1. Taking a derivative along a distributed axis doesn't really make sense. It seems like this has been implemented this way for awhile, but only becomes an issue when running multiple processes.
2. `corrfunc.corr_to_clarray` is extremely slow in some cases. This is still a WIP to fix