### PR TITLE
docs: update citation and dependency information

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ utility code for dealing with Healpix maps, spherical co-ordinates etc.
 
 This package has many dependencies. The following are essential:
 
-* `Python <http://www.python.org/>`_ 2.7 or later
-* `Numpy <http://scipy.org/>`_ (version 1.7 or later)
-* `Scipy <http://scipy.org/>`_
-* `Cython <http://cython.org/>`_
+* `Python <http://www.python.org/>` 3.9 or later
+* `Numpy <http://scipy.org/>` (version 2.0 or later)
+* `Scipy <http://scipy.org/>`
+* `Cython <http://cython.org/>`
 
 It is **strongly** recommended that you use optimized versions of `Numpy` and
 `Scipy` compiled against a multithreaded `BLAS` library such as the `Intel MKL
-<http://www.intel.com/software/products/mkl/>`_ or for AMD chips `ACML
-<http://developer.amd.com/libraries/acml>`_.
+<http://www.intel.com/software/products/mkl/>` or for AMD chips `ACML
+<http://developer.amd.com/libraries/acml>`.
 
 For full functionality there are other packages which are required:
 
-* `Healpy <https://github.com/healpy/healpy>`_ (version 1.8 or later)
-* `h5py <http://www.h5py.org/>`_
+* `Healpy <https://github.com/healpy/healpy>` (version 1.15 or later)
+* `h5py <http://www.h5py.org/>`
 
 As there are several Cython modules which need to be built the `setup.py` must
 be run in some form. Either the standard ::
@@ -28,3 +28,7 @@ be run in some form. Either the standard ::
 or to develop the package ::
 
     $ python setup.py develop [--user]
+
+## Referencing
+
+If you use this package in published scientific work, please cite the corresponding Zenodo listing (https://zenodo.org/records/13181020), along with the two papers that describe various aspects of the simulation implementation: https://arxiv.org/abs/1302.0327 and https://arxiv.org/abs/1401.2095.

--- a/doc/simulation.rst
+++ b/doc/simulation.rst
@@ -16,10 +16,10 @@ different sources of radio emission:
 	* A synthetic population of dimmer point sources.
 	* A gaussian random field to model an unresolved background of sources.
 
-These models are described in more detail in `arXiv:1302.3267`_ and `arXiv:1401.XXXX`_
+These models are described in more detail in `arXiv:1302.0327`_ and `arXiv:1401.2095`_
 
-.. _`arXiv:1302.3267`: http://arxiv.org/abs/1302.3267
-.. _`arXiv:1401.XXXX`: http://arxiv.org/abs/1401.XXXX
+.. _`arXiv:1302.0327`: http://arxiv.org/abs/1302.0327
+.. _`arXiv:1401.2095`: http://arxiv.org/abs/1401.2095
 
 Command Line Tools
 ------------------


### PR DESCRIPTION
Updates broken links to Shaw+ papers, adds citation information to readme, and updates a few package versions listed as dependencies in the readme. (Prompted by https://github.com/radiocosmology/cora/issues/64)