### PR TITLE
LSS computation improvements

### DIFF
--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -296,6 +296,7 @@ def corr_to_clarray(
     xromb: int = 3,
     xwidth: Optional[float] = None,
     q: int = 2,
+    chunksize: int = 50,
 ):
     """Calculate an array of :math:`C_l(\chi_1, \chi_2)`.
 
@@ -319,6 +320,9 @@ def corr_to_clarray(
         calculate from the separation of the first two bins.
     q
         Integration accuracy parameter for the Legendre transform
+    chunksize
+        Chunk size for evaluating discrete samples of angular integrand in batches.
+        Default: 50.
 
     Returns
     -------
@@ -363,8 +367,8 @@ def corr_to_clarray(
     clo = corr_array.local_offset[0]
     _len = corr_array.local_array.shape[0]
 
-    # Split thetas into ~length 50 chunks, otherwise memory will blow up
-    for msec in np.array_split(np.arange(_len), _len // 50):
+    # Split thetas into chunks, otherwise memory will blow up
+    for msec in np.array_split(np.arange(_len), _len // chunksize):
         # Index into the global index in mu
         rc = coord.cosine_rule(mu[clo + msec], xa, xa)
         corr1 = corr(rc)

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -547,6 +547,7 @@ class GenerateBiasedFieldBase(task.SingleTask):
         z = f.redshift if self.lightcone else self.redshift * np.ones_like(f.chi)
         D = f.cosmology.growth_factor(z) / f.cosmology.growth_factor(0)
 
+        f.redistribute("chi")
         fd = f.delta[:].local_array
 
         # Apply any first order bias

--- a/cora/signal/lsscontainers.py
+++ b/cora/signal/lsscontainers.py
@@ -139,7 +139,7 @@ class InterpolatedFunction(memh5.BasicCont):
             )
 
             def _func(x):
-                return f_t * np.sinh(_spline(np.asinh(x / x_t)))
+                return f_t * np.sinh(_spline(np.arcsinh(x / x_t)))
 
             func = _func
 

--- a/cora/signal/lsscontainers.py
+++ b/cora/signal/lsscontainers.py
@@ -14,9 +14,7 @@ from ..util.nputil import FloatArrayLike
 
 
 # Types of interpolation that can be used
-_INTERP_TYPES = [
-    "linear", "log", "sinh", "linear_scipy", "sinh_scipy"
-]
+_INTERP_TYPES = ["linear", "log", "sinh", "linear_scipy", "sinh_scipy"]
 
 
 class InterpolatedFunction(memh5.BasicCont):
@@ -367,6 +365,66 @@ class CorrelationFunction(CosmologyContainer, InterpolatedFunction):
         # where ContainerBase does not correctly call its superconstructor we need to do
         # this explicitly
         self._finish_setup()
+
+
+class MultiFrequencyAngularPowerSpectrum(FZXContainer):
+    """Container for holding C_ell(chi,chi')."""
+
+    _axes = ("ell",)
+
+    def __init__(
+        self,
+        lmax: float,
+        *args,
+        **kwargs,
+    ):
+        # Set ell axis to span from ell=0 to lmax
+        kwargs["ell"] = lmax + 1
+        super().__init__(*args, **kwargs)
+
+    _dataset_spec = {
+        "Cl_phi_phi": {
+            "axes": ["ell", "chi", "chi"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "ell",
+        },
+        "Cl_phi_delta": {
+            "axes": ["ell", "chi", "chi"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "ell",
+        },
+        "Cl_delta_delta": {
+            "axes": ["ell", "chi", "chi"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "ell",
+        },
+    }
+
+    @property
+    def Cl_phi_phi(self):
+        """Phi-phi angular power spectrum."""
+        return self.datasets["Cl_phi_phi"]
+
+    @property
+    def Cl_phi_delta(self):
+        """Phi-delta angular power spectrum."""
+        return self.datasets["Cl_phi_delta"]
+
+    @property
+    def Cl_delta_delta(self):
+        """Delta-delta angular power spectrum."""
+        return self.datasets["Cl_delta_delta"]
+
+    @property
+    def ell(self):
+        """Ell values for stored angular power spectra."""
+        return self.index_map["ell"]
 
 
 class InitialLSS(FZXContainer, containers.HealpixContainer):


### PR DESCRIPTION
This does several things:
1. Incorporate the distributed-axis fixes from https://github.com/radiocosmology/cora/pull/63
2. Allow the user to specify the "chunk size" for samples of the $C_\ell(\chi,\chi')$ integrand in `corr_to_clarray()` and `GenerateInitialLSS`. (It turns out that this doesn't affect performance, but it's good to expose it to the user anyway.)
3. Allow interpolating functions for multiple interpolation methods to be obtained from an `InterpolatedFunction` object.
4. Allow the user to specify the interpolation method for $\xi(r)$ when computing $C_\ell(\chi,\chi')$. It turns out that this can have a strong impact on performance - see https://github.com/radiocosmology/cora/issues/62.
5. Refactor `GenerateInitialLSS` into separate tasks for computing $C_\ell(\chi,\chi')$ and generating maps. We also retain a wrapper for these two tasks that uses the original `GenerateInitialLSS` syntax, for backwards-compatibility.