### PR TITLE
accurate finger of god kenel and nonuniform $d\chi(z)$

### DIFF
--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -346,18 +346,23 @@ def corr_to_clarray(
     # *output* maps as it the transform from theta -> l seems to wash it out
     if xromb > 0:
         # Calculate the half bin width
-        # TODO: make this more accurate for non-uniform bin spacings
-        xsort = np.sort(xarray)
-        xhalf = np.abs(xsort[1] - xsort[0]) / 2.0 if xwidth is None else xwidth / 2.0
+        if xwidth is None:
+            xhalf = np.ndarray(shape=xarray.shape)
+            # width for first and second bin are same
+            xhalf[0] = np.abs(xarray[1] - xarray[0]) / 2.0
+            xhalf[1:] = np.abs(xarray[1:] - xarray[:-1]) / 2.0
+        else:
+            # for continuity with previous convention of allowing to choose xwidth
+            xhalf = np.ones(shape=xarray.shape) * xwidth / 2.0
+
         xint = 2**xromb + 1
 
         # Get the quadrature points and weights.
         x_r, x_w, x_wsum = ss.roots_legendre(xint, mu=True)
-        x_r *= xhalf
         x_w /= x_wsum
 
         # Calculate the extended z-array with the extra intervals to integrate over
-        xa = (xarray[:, np.newaxis] + x_r[np.newaxis, :]).flatten()
+        xa = (xarray[:, np.newaxis] + xhalf[:, np.newaxis] * x_r).flatten()
 
     else:
         xa = xarray

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -247,10 +247,14 @@ class CalculateMultiFrequencyAngularPowerSpectrum(task.SingleTask):
     xromb : int, optional
         Gauss-Legendre quadrature order for integrating C_ell over radial
         bins. (Used Romberg integration in a previous version, hence the
-        name xromb.) xromb=0 turns off this integral. Default: 2.
+        name xromb.) xromb=0 turns off this integral. When dealing with
+        nonlinear matter power spectrum, for sub-percent accuracy up to
+        l ~ 1500, xromb = 3 is recommended. Default: 2.
     leg_q : int, optional
         Integration accuracy parameter for Legendre transform for C_ell
-        computation. Default: 4.
+        computation. When dealing with nonlinear matter power spectrum,
+        for sub-percent accuracy up to l ~ 1500, leg_q = 16 is recommended.
+        Default: 4.
     leg_chunksize: int, optional
         Chunk size for evaluating samples of C_ell integrand. Changing
         from default value is unlikely to affect performance. Default: 50.

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -309,7 +309,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(task.SingleTask):
         # power will alias back down when the map is transformed later on
         lmax = 3 * self.nside - 1
 
-        self.log.debug("Generating C_l(x, x') for phi-phi")
+        self.log.debug("Generating C_l(x, x') for delta-delta")
         cla0 = corrfunc.corr_to_clarray(
             corr0,
             lmax,
@@ -329,7 +329,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(task.SingleTask):
             chunksize=self.leg_chunksize,
         )
 
-        self.log.debug("Generating C_l(x, x') for delta-delta")
+        self.log.debug("Generating C_l(x, x') for phi-phi")
         cla4 = corrfunc.corr_to_clarray(
             corr4,
             lmax,
@@ -352,9 +352,9 @@ class CalculateMultiFrequencyAngularPowerSpectrum(task.SingleTask):
                 lmax=lmax,
             )
 
-        out_cont.Cl_phi_phi[:] = cla0
+        out_cont.Cl_delta_delta[:] = cla0
         out_cont.Cl_phi_delta[:] = cla2
-        out_cont.Cl_delta_delta[:] = cla4
+        out_cont.Cl_phi_phi[:] = cla4
 
         return out_cont
 
@@ -425,10 +425,10 @@ class GenerateInitialLSSFromCl(task.SingleTask):
         # Create extended covariance matrix capturing cross-correlations
         # between the phi and delta fields
         cla = mpiarray.zeros((len(self.aps.ell), 2 * nz, 2 * nz), axis=0)
-        cla[:, nz:, nz:] = self.aps.Cl_phi_phi[:]
+        cla[:, nz:, nz:] = self.aps.Cl_delta_delta[:]
         cla[:, :nz, nz:] = self.aps.Cl_phi_delta[:]
         cla[:, nz:, :nz] = self.aps.Cl_phi_delta[:]
-        cla[:, :nz, :nz] = self.aps.Cl_delta_delta[:]
+        cla[:, :nz, :nz] = self.aps.Cl_phi_phi[:]
 
         # Generate map
         self.log.info(f"Generating realisation of fields using seed {self.seed}")

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -578,7 +578,7 @@ def exponential_FoG_kernel(
 
     # The zero-lag bins are a special case because of the reflection about zero
     # Here the weight is slightly less than if we evaluated exactly at zero
-    np.fill_diagonal(K, np.exp(-ar * dchi / 4) * sinhc(ar * dchi / 4))
+    np.fill_diagonal(K, np.diagonal(np.exp(-ar * dchi / 4) * sinhc(ar * dchi / 4)))
 
     # Normalise each row to ensure conservation of mass
     K /= np.sum(K, axis=1)[:, np.newaxis]


### PR DESCRIPTION
This implements the following:

1 Correctly assign the diagonal of the FoG kernel (corresponding to $x_{||} = 0$)
2 Implement nonuniform $d\chi(z)$ through `xhalf` in `corr_to_clarray`
3 Modify the doc string of `CalculateMultiFrequencyAngularPowerSpectrum` to include the recommended values of `leg_q` and `xromb` parameters
