### PR TITLE
Generating shot noise map with optional Finger-of-God damping

### DIFF
--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -1493,6 +1493,9 @@ class GenerateFlatSpectrumMap(task.SingleTask, RandomTask):
         m.attrs["voxvol_ref"] = voxvol
         m.attrs["central_redshift"] = redshift[ref_chan]
 
+        # Distribute in frequency, because other tasks often expect this
+        m.redistribute("freq")
+
         if self._count == self.niter:
             raise pipeline.PipelineStopIteration
 

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Optional, Tuple
+from functools import cache
 
 import healpy
 import numpy as np
@@ -28,6 +29,12 @@ from .lsscontainers import (
     MatterPowerSpectrum,
     _INTERP_TYPES,
 )
+
+
+@cache
+def get_cosmo(*args, **kwargs):
+    # get default Cosmology object from cora.util
+    return Cosmology(*args, **kwargs)
 
 
 # Power spectra that can be used
@@ -1379,3 +1386,151 @@ def za_density_sph(
     out[:] -= 1.0
 
     return out
+
+
+class GenerateFlatSpectrumMap(task.SingleTask, RandomTask):
+    """Generate a full-frequency sky map of a flat-spectrum noise-like signal.
+
+    The user can either specify the per-voxel variance or the desired value
+    of the 3d power spectrum of the map. In the latter case, voxels are populated
+    with zero-mean Gaussian noise with variance P_SN / V_voxel ** 0.5. The user
+    can also specify whether V_voxel should be calculated per frequency channel
+    or be evaluated at the middle channel of the band. If one expects a 3d power
+    spectrum to be measured from the map in the constant-redshift approximation,
+    it's more accurate to use a constant V_voxel when generating the map.
+
+    Although `seed` is not listed below, it can be specified by the user, since
+    this task inherits from `draco.util.random.RandomTask`.
+
+    Attributes
+    ----------
+    nside : int
+        The nside of the Healpix map.
+    frequencies : np.ndarray
+        The frequencies to evaulate at.
+    full_pol : bool
+        If True, all Stokes parameters are stored. If False, only Stokes I is
+        stored. Default: True.
+    variance : float
+        Per-voxel variance of the signal, in Kelvin^2. Only one of `variance`
+        and `P_SN` can be specified (an exception will be raised if both or
+        neither are specified). Default: None.
+    P_SN : float
+        Desired value of constant-redshift 3d power spectrum of map.
+        Default: None.
+    use_freq_dependent_voxel_volume : bool
+        Whether to use/store frequency-dependent voxel volume. Default: False.
+    niter : int
+        Number of realizations to generate.
+    """
+
+    nside = config.Property(proptype=int, default=512)
+    frequencies = config.Property(proptype=lssutil.linspace, default=None)
+    full_pol = config.Property(proptype=bool, default=True)
+    variance = config.Property(proptype=float, default=None)
+    P_SN = config.Property(proptype=float, default=None)
+    use_freq_dependent_voxel_volume = config.Property(proptype=bool, default=False)
+    niter = config.Property(proptype=int, default=1)
+
+    def setup(self):
+        """Set up task."""
+        if ((self.variance is None) and (self.P_SN is None)) or (
+            (self.variance is not None) and (self.P_SN is not None)
+        ):
+            raise ValueError("Only one of variance or P_SN can be specified.")
+
+    def process(self) -> Map:
+        """Generate a flat-spectrum noise-like sky map with given power.
+
+        Returns
+        -------
+        out_map
+            Output Map container.
+        """
+
+        # Form frequency map in appropriate format to feed into Map container
+        freq = self.frequencies
+        nfreq = len(freq)
+        redshift = units.nu21 / freq - 1
+        freqmap = np.zeros(nfreq, dtype=[("centre", np.float64), ("width", np.float64)])
+        freqmap["centre"][:] = freq[:]
+        freqmap["width"][:] = np.abs(np.diff(freq[:])[0])
+
+        # Find index of central channel
+        ref_chan = int(nfreq / 2.0)
+
+        # Compute voxel volume
+        omega = healpy.nside2pixarea(self.nside)  # Pixel area in sr
+        if self.use_freq_dependent_voxel_volume:
+            dV = differential_comoving_volume(redshift)
+            dz = lssutil.calculate_width(redshift)
+        else:
+            dV = differential_comoving_volume(redshift[ref_chan])
+            dz = redshift[ref_chan + 1] - redshift[ref_chan]
+        voxvol = dV * dz * omega
+
+        # Make new map container and distribute in pixel, to make it easier to
+        # fill map with freq- and pol-dependent values
+        m = Map(freq=freqmap, polarisation=self.full_pol, nside=self.nside)
+        m.redistribute("pixel")
+
+        # Set standard deviation of map values
+        if self.variance is not None:
+            scale = self.variance**0.5
+        else:
+            scale = self.P_SN**0.5
+            if self.use_freq_dependent_voxel_volume:
+                scale /= voxvol[:, np.newaxis] ** 0.5
+            else:
+                scale /= voxvol**0.5
+
+        # Fill local section of map with random values
+        m.map[:].local_array[:, 0, :] = self.rng.normal(
+            scale=scale, size=(nfreq, m.map[:].local_shape[-1])
+        )
+
+        # Save voxel volume(s) as attribute
+        m.attrs["voxvol_ref"] = voxvol
+        m.attrs["central_redshift"] = redshift[ref_chan]
+
+        if self._count == self.niter:
+            raise pipeline.PipelineStopIteration
+
+        return m
+
+
+def differential_comoving_volume(z, cosmo=None):
+    """Differential comoving volume at redshift z.
+
+    Useful for calculating the effective comoving volume.
+    For example, allows for integration over a comoving volume that has a
+    sensitivity function that changes with redshift. The total comoving
+    volume is given by integrating ``differential_comoving_volume`` to
+    redshift ``z`` and multiplying by a solid angle.
+
+    This is taken from:
+    https://docs.astropy.org/en/stable/_modules/astropy/cosmology/flrw/base.html#FLRW.differential_comoving_volume
+
+    Parameters
+    ----------
+    z : float
+     redshift
+    cosmo: Cosmology object
+        Default is cora.util.Cosmology() default.
+
+    Returns
+    -------
+    dV : float
+      Differential comoving volume per redshift per steradian at each
+      input redshift. unit (Mpc/h)^3
+    """
+
+    if cosmo is None:
+        cosmo = get_cosmo()
+
+    H_z = cosmo.H(z) * (
+        cosmo._unit_distance / 1000.0
+    )  # H(z) in unit [(km . h) / (Mpc . sec)]
+    dm = cosmo.comoving_distance(z)  # Mpc / h
+
+    return dm**2 * (units.c / 1e3) / H_z

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -350,7 +350,7 @@ def pk_flat(
     # transform a complex field
     almn_square = np.array([hputil.sphtrans_complex(m, lmax) for m in cn])
 
-    l = np.arange(lmax + 1)
+    ell = np.arange(lmax + 1)
     n = np.arange(cn.shape[0])
 
     # Sum over m direction
@@ -364,10 +364,10 @@ def pk_flat(
         cln = (almn_square * almn_square2.conj()).sum(axis=-1).real
 
     # Divide by the number of m's at each l to get an average
-    cln /= (2 * l + 1)[np.newaxis, :]
+    cln /= (2 * ell + 1)[np.newaxis, :]
 
     # Get the effective axes in k space
-    kperp = l / chi_mean
+    kperp = ell / chi_mean
     kpar = 2 * np.pi * n / L
 
     cln *= L * chi_mean**2

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -339,7 +339,7 @@ def pk_flat(
         lmax = 3 * nside
 
     N = len(chi)
-    dx = chi.ptp() / (N - 1)
+    dx = np.ptp(chi) / (N - 1)
 
     # The effective L is slightly longer than the range because of the channel widths
     L = N * dx


### PR DESCRIPTION
This PR builds on Arnab's (https://github.com/radiocosmology/cora/pull/80), refactoring and adding the following features:
- Ability to directly specify the desired 3d shot noise power spectrum ($P_{\rm SN}$) in units of $K^2\ h^{-3}\ {\rm Mpc}^3$, as an alternative to specifying the per-pixel variance of the map
- Ability to feed a `Map` container to `cora.signal.lss.FingersOfGod`, so that FoG damping can be applied directly to a shot-noise-map.

Idealize, the new shot noise map task would be refactored together with `cora.signal.lss.AddCorrelatedShotNoise`, since there is some redundant code that could be put into a base class, but let's leave that for the future.