### PR TITLE
Misc. bug fixes

### DIFF
--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -1527,7 +1527,7 @@ class GenerateFlatSpectrumMap(task.SingleTask, RandomTask):
         else:
             scale = self.P_SN**0.5
             if self.use_freq_dependent_voxel_volume:
-                scale /= voxvol[:, np.newaxis] ** 0.5
+                scale /= voxvol[:, np.newaxis, np.newaxis] ** 0.5
             else:
                 scale /= voxvol**0.5
 

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -930,7 +930,7 @@ class BiasedLSSToMap(task.SingleTask):
     ----------
     use_mean_21cmT : bool
         Multiply map by mean 21cm temperature as a function of z (default: False).
-    use_prefactor : float
+    map_prefactor : float
         Scale by an arbitrary prefactor.
     lognormal : bool
         Use a lognormal transform to guarantee that the density is always positive (i.e.

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -185,8 +185,8 @@ class CalculateCorrelations(task.SingleTask):
 class BlendNonLinearPowerSpectrum(task.SingleTask):
     """Generate a controllable mix between a linear and non-linear power spectrum.
 
-    Blends a linear and non-linear power spectrum by linear interpolating in
-    :math:`\log(P(k))`.
+    Blends a linear and non-linear power spectrum by computing a linear
+    combination of the two spectra.
 
     Attributes
     ----------
@@ -237,7 +237,7 @@ class BlendNonLinearPowerSpectrum(task.SingleTask):
         psnl = ps_nonlinear.datasets["powerspectrum"][:]
 
         ps_linear.datasets["powerspectrum"][:] = (
-            psl ** (1 - self.alpha_NL) * psnl**self.alpha_NL
+            psl * (1 - self.alpha_NL) + psnl * self.alpha_NL
         )
         ps_linear.attrs["tag"] = f"psblend_alphaNL_{self.alpha_NL}"
 


### PR DESCRIPTION
Two bug fixes here:
- `BlendNonLinearPowerSpectrum`: bug in interpolating between linear and nonlinear power spectra. (The previous version had the correct limits when $\alpha_{\rm NL}=0$ or $1$, but was incorrect for intermediate values. I can't think of a case where we've used intermediate values previously, but for generating simulations to validate the auto spectrum modelling, we were getting incorrect results until @shabbir137 and I discovered this bug.)
- `GenerateFlatSpectrumMap`: bug in propagating frequency-dependent voxel volume into random-number generation, when specifying a per-pixel variance instead of a target shot noise power spectrum (noticed by @Arnab-half-blood-prince)