### PR TITLE
Fix no-lightcone options in sky sims

### DIFF
--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -947,7 +947,7 @@ class BiasedLSSToMap(task.SingleTask):
     omega_HI_model = config.enum(lssmodels.omega_HI.models(), default="Crighton2015")
 
     def process(self, biased_lss: BiasedLSS) -> Map:
-        """Generate a realisation of the LSS initial conditions.
+        """Convert a BiasedLSS contailer into a Map container.
 
         Parameters
         ----------

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -1185,7 +1185,10 @@ class FingersOfGod(task.SingleTask):
 
         # Get redshift and chi arrays
         if isinstance(field, BiasedLSS):
-            redshift = field.redshift
+            if field.lightcone:
+                redshift = field.redshift
+            else:
+                redshift = field.fixed_redshift * np.ones_like(field.redshift)
             chi = field.chi
         else:
             redshift = units.nu21 / field.freq - 1.0

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -985,8 +985,11 @@ class BiasedLSSToMap(task.SingleTask):
 
         # If desired, multiply by Tb(z)
         if self.use_mean_21cmT:
+            if biased_lss.lightcone:
+                z = biased_lss.redshift
+            else:
+                z = biased_lss.fixed_redshift * np.ones_like(biased_lss.redshift)
 
-            z = biased_lss.redshift
             omHI = lssmodels.omega_HI.evaluate(z, model=self.omega_HI_model)
             T_b = lssmodels.mean_21cm_temperature(biased_lss.cosmology, z, omHI)
 


### PR DESCRIPTION
This fixes a few tasks to correctly handle sky simulations where a fixed redshift is used instead of implementing evolution along the lightcone.