### PR TITLE
Add macos compiler flags and CI tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,6 @@ jobs:
           brew update
           CC=mpicc brew install open-mpi hdf5-mpi
 
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,10 +2,10 @@ name: cora-ci-build
 on:
   pull_request:
     branches:
-    - main
+      - main
   push:
     branches:
-    - main
+      - main
 
 jobs:
 
@@ -13,67 +13,81 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.14"
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
-    - name: Install linting requirements
-      run: pip install black
+      - name: Install linting requirements
+        run: pip install black
 
-    - name: Check code with black
-      run: black --check .
+      - name: Check code with black
+        run: black --check .
 
   run-tests:
 
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.10", "3.14"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    - name: Install apt dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libhdf5-serial-dev libopenmpi-dev openmpi-bin libgsl-dev
+      - name: Install apt dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libhdf5-serial-dev libopenmpi-dev openmpi-bin libgsl-dev
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Install brew dependencies
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew update
+          CC=mpicc brew install open-mpi hdf5-mpi
+      
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install pip dependencies
-      run: |
-        pip install -e .
-        pip install -e .[test]
+      - name: Update pip
+        run: pip install --upgrade pip
 
-    - name: Run serial tests
-      run: pytest --doctest-modules tests/
+      - name: Disable OpenMP warning on macos
+        if: matrix.os == 'macos-latest'
+        run: export CORA_NO_OPENMP=1
+
+      - name: Install pip dependencies
+        run: CC=mpicc pip install -e ".[test]"
+
+      - name: Run serial tests
+        run: pytest --doctest-modules tests/
 
   build-docs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.14"
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
 
-    - name: Install apt dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libhdf5-serial-dev libopenmpi-dev openmpi-bin libgsl-dev
+      - name: Install apt dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libhdf5-serial-dev libopenmpi-dev openmpi-bin libgsl-dev
 
-    - name: Install pip dependencies
-      run: |
-        pip install -e .
-        pip install -e .[docs]
+      - name: Install pip dependencies
+        run: |
+          pip install -e .
+          pip install -e .[docs]
 
-    - name: Build sphinx docs
-      run: sphinx-build -W -b html doc/ doc/_build/html
+      - name: Build sphinx docs
+        run: sphinx-build -W -b html doc/ doc/_build/html

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,8 @@ jobs:
         run: |
           brew update
           CC=mpicc brew install open-mpi hdf5-mpi
-      
+
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
@@ -60,7 +61,11 @@ jobs:
 
       - name: Disable OpenMP warning on macos
         if: matrix.os == 'macos-latest'
-        run: export CORA_NO_OPENMP=1
+        run: echo "CORA_NO_OPENMP=1" >> "$GITHUB_ENV"
+
+      - name: Disable zstd assembly for recent macos where prebuilt missing
+        if: matrix.os == 'macos-latest' && matrix.python-version == '3.14'
+        run: echo "CFLAGS=-DZSTD_DISABLE_ASM" >> "$GITHUB_ENV"
 
       - name: Install pip dependencies
         run: CC=mpicc pip install -e ".[test]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cora"
 description = "Simulation and modelling of low frequency radio skies"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     { name = "The CHIME Collaboration", email = "lgray@phas.ubc.ca" }
 ]

--- a/setup.py
+++ b/setup.py
@@ -5,28 +5,52 @@ required to build cython extensions.
 """
 
 import os
-import tempfile
-import sysconfig
+import platform
+import re
 import subprocess
+import sysconfig
+import tempfile
 
 import numpy
 from Cython.Build import cythonize
 from setuptools import setup
 from setuptools.extension import Extension
 
-USE_LTO = True
-
 # Subset of `-ffast-math` compiler flags which should
 # preserve IEEE compliance
 FAST_MATH_ARGS = ["-O3", "-fno-math-errno", "-fno-trapping-math"]
 # Flags required by the compiler
-COMPILE_FLAGS = ["-std=c99", "-march=native", *FAST_MATH_ARGS]
-LINK_FLAGS = []
+COMPILE_FLAGS = ["-flto", *FAST_MATH_ARGS]
 
-if USE_LTO:
-    COMPILE_FLAGS.append("-flto")
-    # Flags required by the linker
-    LINK_FLAGS.extend(("-flto", *FAST_MATH_ARGS))
+
+def get_mcpu_flag():
+    """Try to figure out the relevant cpu flags."""
+    system = platform.system().lower()
+
+    if system != "darwin":
+        # Making no assumptions about other systems
+        return "-march=native" if system == "linux" else ""
+
+    try:
+        # Get CPU model: "Apple M3 Pro", etc.
+        cpu_brand = (
+            subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"])
+            .decode()
+            .strip()
+            .lower()
+        )
+    except:  # noqa: E722
+        return ""
+
+    # See if we can match against specifc Metal generations
+    match = re.match(r"apple m\d", cpu_brand)
+
+    if match:
+        cpu = match[0].lower().strip().replace(" ", "-")
+
+        return f"-mcpu={cpu}"
+
+    return "-mcpu=apple-m1"
 
 
 def _compiler_supports_openmp():
@@ -61,7 +85,6 @@ if not os.environ.get("CORA_NO_OPENMP"):
     if _compiler_supports_openmp():
         # OpenMP flags are required by both the compiler and the linker
         COMPILE_FLAGS.append("-fopenmp")
-        LINK_FLAGS.append("-fopenmp")
     else:
         cc = os.environ.get("CC", sysconfig.get_config_var("CC"))
         print(
@@ -72,6 +95,12 @@ if not os.environ.get("CORA_NO_OPENMP"):
             "variable CORA_NO_OPENMP to any truth-like value."
         )
 
+if "-fopenmp" not in COMPILE_FLAGS and platform.system().lower() == "darwin":
+    # Use Apple Accelerate
+    COMPILE_FLAGS.extend(("-framework", "Accelerate"))
+
+COMPILE_FLAGS.append(get_mcpu_flag())
+
 extensions = [
     # Cubic spline extension
     Extension(
@@ -79,7 +108,7 @@ extensions = [
         ["cora/util/cubicspline.pyx"],
         include_dirs=[numpy.get_include()],
         extra_compile_args=COMPILE_FLAGS,
-        extra_link_args=LINK_FLAGS,
+        extra_link_args=COMPILE_FLAGS,
     ),
     # Bi-linear map extension
     Extension(
@@ -87,7 +116,7 @@ extensions = [
         ["cora/util/bilinearmap.pyx"],
         include_dirs=[numpy.get_include()],
         extra_compile_args=COMPILE_FLAGS,
-        extra_link_args=LINK_FLAGS,
+        extra_link_args=COMPILE_FLAGS,
     ),
     # particle-mesh gridding extension
     Extension(
@@ -95,7 +124,7 @@ extensions = [
         ["cora/util/pmesh.pyx"],
         include_dirs=[numpy.get_include()],
         extra_compile_args=COMPILE_FLAGS,
-        extra_link_args=LINK_FLAGS,
+        extra_link_args=COMPILE_FLAGS,
     ),
 ]
 


### PR DESCRIPTION
Also, deals with an edge case where `zstd` tries to use x86 assembly on arm64 macos, which occurs when trying to build numcodecs  (blosc specifically). In this case, it seems like there aren't any macos wheels available for numcodecs for python 3.14.