### PR TITLE
Updates for auto spectrum simulations

### DIFF
--- a/cora/core/skysim.py
+++ b/cora/core/skysim.py
@@ -7,7 +7,7 @@ from caput import mpiarray
 from cora.util import hputil, nputil
 
 
-def clarray(aps, lmax, zarray, zromb=3, zwidth=None):
+def clarray(aps, lmax, zarray, zromb=3, zwidth=None, chunksize = 5):
     """Calculate an array of C_l(z, z').
 
     Parameters
@@ -23,6 +23,9 @@ def clarray(aps, lmax, zarray, zromb=3, zwidth=None):
     zwidth : scalar, optional
         Width of frequency channel to integrate over. If None (default),
         calculate from the separation of the first two bins.
+    chunksize : int, optional
+        Chunk size for performing channel integral in batches of ell values.
+        Default: 5.
 
     Returns
     -------
@@ -48,7 +51,7 @@ def clarray(aps, lmax, zarray, zromb=3, zwidth=None):
             zarray[:, np.newaxis] + np.linspace(-zhalf, zhalf, zint)[np.newaxis, :]
         ).flatten()
 
-        lsections = np.array_split(np.arange(lmax + 1), lmax // 5)
+        lsections = np.array_split(np.arange(lmax + 1), lmax // chunksize)
 
         cla = np.zeros((lmax + 1, zlen, zlen), dtype=np.float64)
 

--- a/cora/core/skysim.py
+++ b/cora/core/skysim.py
@@ -1,28 +1,59 @@
 import numpy as np
 import scipy.linalg as la
 import scipy.integrate as si
+import scipy.special as ss
 import healpy
 
 from caput import mpiarray
 from cora.util import hputil, nputil
 
 
-def clarray(aps, lmax, zarray, zromb=3, zwidth=None, chunksize = 5):
+def clarray(
+    aps,
+    lmax,
+    zarray,
+    gauss_legendre=False,
+    zromb=3,
+    zwidth=None,
+    chunksize=5,
+):
     """Calculate an array of C_l(z, z').
+
+    The zromb parameter controls whether to integrate the angular
+    power spectrum over each frequency channel. Two schemes are
+    available:
+
+    1. Legacy Romberg integration that assumes each channel
+    has the same redshift width. Note that this is a bad approximation
+    if working within a sufficiently wide frequency band, so the
+    second scheme is strongly recommended in that case.
+
+    2. Gauss-Legendre quadrature that can either assume a constant width
+    or use the correct per-chennel width. This scheme is almost identical
+    to the one in `cora.signal.corrfunc.corr_to_clarray`, except that
+    here the integration is in redshift instead of comoving distance.
 
     Parameters
     ----------
     aps : function
-        The angular power spectrum to calculate.
+        The angular power spectrum to calculate, with arguments
+        (ell, z, z').
     lmax : integer
         Maximum l to calculate up to.
-    zarray : array_like
-        Array of z's to calculate at.
-    zromb : integer
-        The Romberg order for integrating over frequency samples.
+    zarray : array_like, optional
+        Array of redshifts to calculate at.
+    gauss_legendre : bool, optional
+        Use Gauss-Legendre quadrature for channel integration (as in 
+        cora.signal.corrfunc.corr_to_clarray). If False, use older 
+        Romberg scheme. Default: False.
+    zromb : integer, optional
+        The Romberg or Gauss-Legendre order for integrating over 
+        each channel. If 0, this integration is turned off. Default: 3.
     zwidth : scalar, optional
-        Width of frequency channel to integrate over. If None (default),
-        calculate from the separation of the first two bins.
+        Constant redshift width of frequency channel to integrate over. 
+        If None, calculated from the separation of the first two bins 
+        for the Romberg scheme, or computed separately for each channel
+        in the Gauss-Legendre scheme. Default: None.
     chunksize : int, optional
         Chunk size for performing channel integral in batches of ell values.
         Default: 5.
@@ -41,33 +72,81 @@ def clarray(aps, lmax, zarray, zromb=3, zwidth=None, chunksize = 5):
         )
 
     else:
-        zsort = np.sort(zarray)
-        zhalf = np.abs(zsort[1] - zsort[0]) / 2.0 if zwidth is None else zwidth / 2.0
-        zlen = zarray.size
-        zint = 2**zromb + 1
-        zspace = 2.0 * zhalf / 2**zromb
+        # Gauss-Legendre scheme
+        if gauss_legendre:
 
-        za = (
-            zarray[:, np.newaxis] + np.linspace(-zhalf, zhalf, zint)[np.newaxis, :]
-        ).flatten()
+            # Get number of redshifts            
+            zlen = zarray.size
 
-        lsections = np.array_split(np.arange(lmax + 1), lmax // chunksize)
+            # Calculate the half-bin width
+            if zwidth is None:
+                zhalf = np.ndarray(shape=zarray.shape)
+                # Compute width for each channel, using same width for first
+                # and second channel
+                zhalf[0] = np.abs(zarray[1] - zarray[0]) / 2.0
+                zhalf[1:] = np.abs(zarray[1:] - zarray[:-1]) / 2.0
+            else:
+                # Use constant channel width
+                zhalf = np.ones(shape=zarray.shape) * zwidth / 2.0
 
-        cla = np.zeros((lmax + 1, zlen, zlen), dtype=np.float64)
+            # Set number of quadrature points, and get points and weights
+            zint = 2**zromb + 1
+            z_r, z_w, z_wsum = ss.roots_legendre(zint, mu=True)
+            z_w /= z_wsum
 
-        for lsec in lsections:
-            clt = aps(
-                lsec[:, np.newaxis, np.newaxis],
-                za[np.newaxis, :, np.newaxis],
-                za[np.newaxis, np.newaxis, :],
-            )
+            # Calculate the extended xarray with the extra intervals to integrate over
+            za = (zarray[:, np.newaxis] + zhalf[:, np.newaxis] * z_r).flatten()
 
-            clt = clt.reshape(-1, zlen, zint, zlen, zint)
+            # Make array to store final results
+            cla = np.zeros((lmax + 1, zlen, zlen), dtype=np.float64)
 
-            clt = si.romb(clt, dx=zspace, axis=4)
-            clt = si.romb(clt, dx=zspace, axis=2)
+            # Determine ell chunks
+            lsections = np.array_split(np.arange(lmax + 1), lmax // chunksize)
 
-            cla[lsec] = clt / (2 * zhalf) ** 2  # Normalise
+            for lsec in lsections:
+                # Get C_ell(z, z') values for this chunk
+                clt = aps(
+                    lsec[:, np.newaxis, np.newaxis],
+                    za[np.newaxis, :, np.newaxis],
+                    za[np.newaxis, np.newaxis, :],
+                )
+
+                # Perform Gauss-Legendre quandrature via matrix multiplications
+                clt = clt.reshape(-1, zint)
+                clt = np.matmul(clt, z_w).reshape(-1, zlen, zint, zlen)
+                clt = np.matmul(clt.transpose(0, 1, 3, 2), z_w)
+
+                cla[lsec] = clt
+
+        # Romberg scheme
+        else:
+            zsort = np.sort(zarray)
+            zhalf = np.abs(zsort[1] - zsort[0]) / 2.0 if zwidth is None else zwidth / 2.0
+            zlen = zarray.size
+            zint = 2**zromb + 1
+            zspace = 2.0 * zhalf / 2**zromb
+
+            za = (
+                zarray[:, np.newaxis] + np.linspace(-zhalf, zhalf, zint)[np.newaxis, :]
+            ).flatten()
+
+            lsections = np.array_split(np.arange(lmax + 1), lmax // chunksize)
+
+            cla = np.zeros((lmax + 1, zlen, zlen), dtype=np.float64)
+
+            for lsec in lsections:
+                clt = aps(
+                    lsec[:, np.newaxis, np.newaxis],
+                    za[np.newaxis, :, np.newaxis],
+                    za[np.newaxis, np.newaxis, :],
+                )
+
+                clt = clt.reshape(-1, zlen, zint, zlen, zint)
+
+                clt = si.romb(clt, dx=zspace, axis=4)
+                clt = si.romb(clt, dx=zspace, axis=2)
+
+                cla[lsec] = clt / (2 * zhalf) ** 2  # Normalise
 
         return cla
 

--- a/cora/core/skysim.py
+++ b/cora/core/skysim.py
@@ -43,15 +43,15 @@ def clarray(
     zarray : array_like, optional
         Array of redshifts to calculate at.
     gauss_legendre : bool, optional
-        Use Gauss-Legendre quadrature for channel integration (as in 
-        cora.signal.corrfunc.corr_to_clarray). If False, use older 
+        Use Gauss-Legendre quadrature for channel integration (as in
+        cora.signal.corrfunc.corr_to_clarray). If False, use older
         Romberg scheme. Default: False.
     zromb : integer, optional
-        The Romberg or Gauss-Legendre order for integrating over 
+        The Romberg or Gauss-Legendre order for integrating over
         each channel. If 0, this integration is turned off. Default: 3.
     zwidth : scalar, optional
-        Constant redshift width of frequency channel to integrate over. 
-        If None, calculated from the separation of the first two bins 
+        Constant redshift width of frequency channel to integrate over.
+        If None, calculated from the separation of the first two bins
         for the Romberg scheme, or computed separately for each channel
         in the Gauss-Legendre scheme. Default: None.
     chunksize : int, optional
@@ -75,7 +75,7 @@ def clarray(
         # Gauss-Legendre scheme
         if gauss_legendre:
 
-            # Get number of redshifts            
+            # Get number of redshifts
             zlen = zarray.size
 
             # Calculate the half-bin width
@@ -121,7 +121,9 @@ def clarray(
         # Romberg scheme
         else:
             zsort = np.sort(zarray)
-            zhalf = np.abs(zsort[1] - zsort[0]) / 2.0 if zwidth is None else zwidth / 2.0
+            zhalf = (
+                np.abs(zsort[1] - zsort[0]) / 2.0 if zwidth is None else zwidth / 2.0
+            )
             zlen = zarray.size
             zint = 2**zromb + 1
             zspace = 2.0 * zhalf / 2**zromb

--- a/cora/core/skysim.py
+++ b/cora/core/skysim.py
@@ -21,6 +21,7 @@ def clarray(
     chi_func=None,
     channel_profile=None,
     channel_profile_limit=0.5,
+    verbose=False,
 ):
     """Calculate an array of C_l(z, z').
 
@@ -83,6 +84,9 @@ def clarray(
     channel_profile_limit : float, optional
         Determines within which to integrate the channel profile.
         Default: 0.5.
+    verbose : bool, optional
+        Whether to print status messages to track progress as a function of
+        ell. Default: False.
 
     Returns
     -------
@@ -147,6 +151,9 @@ def clarray(
             lsections = np.array_split(np.arange(lmax + 1), lmax // chunksize)
 
             for lsec in lsections:
+                if verbose:
+                    print(f"Computing for ell={lsec} out of {lmax}")
+
                 # Get C_ell(z, z') values for this chunk
                 clt = aps(
                     lsec[:, np.newaxis, np.newaxis],
@@ -202,6 +209,9 @@ def clarray(
             cla = np.zeros((lmax + 1, zlen, zlen), dtype=np.float64)
 
             for lsec in lsections:
+                if verbose:
+                    print(f"Computing for ell={lsec} out of {lmax}")
+
                 clt = aps(
                     lsec[:, np.newaxis, np.newaxis],
                     za[np.newaxis, :, np.newaxis],

--- a/cora/core/skysim.py
+++ b/cora/core/skysim.py
@@ -6,6 +6,7 @@ import healpy
 
 from caput import mpiarray
 from cora.util import hputil, nputil
+from cora.signal.lssutil import diff2
 
 
 def clarray(
@@ -16,6 +17,8 @@ def clarray(
     zromb=3,
     zwidth=None,
     chunksize=5,
+    second_chi_deriv=False,
+    chi_func=None,
 ):
     """Calculate an array of C_l(z, z').
 
@@ -57,12 +60,24 @@ def clarray(
     chunksize : int, optional
         Chunk size for performing channel integral in batches of ell values.
         Default: 5.
+    second_chi_deriv : bool, optional
+        Whether to compute second derivative of computed C_l(z,z') in each
+        of z and z', as derivatives in comoving distance. This can be used
+        for testing computations involving the Kaiser redshift-space
+        distorition term. Default: False.
+    chi_func : function, optional
+        If `second_chi_deriv` is True, this is the function that converts
+        redshift to comoving distance that is used in the finite-difference
+        computation. Default: None.
 
     Returns
     -------
     aps : np.ndarray[lmax+1, len(zarray), len(zarray)]
         Array of the C_l(z,z') values.
     """
+
+    if second_chi_deriv and chi_func is None:
+        raise RuntimeError("Must specify chi_func if using second_chi_deriv")
 
     if zromb == 0:
         return aps(
@@ -110,6 +125,11 @@ def clarray(
                     za[np.newaxis, :, np.newaxis],
                     za[np.newaxis, np.newaxis, :],
                 )
+
+                if second_chi_deriv:
+                    xarray = chi_func(za)
+                    clt = diff2(clt, xarray, axis=1)
+                    clt = diff2(clt, xarray, axis=2)
 
                 # Perform Gauss-Legendre quandrature via matrix multiplications
                 clt = clt.reshape(-1, zint)

--- a/cora/core/skysim.py
+++ b/cora/core/skysim.py
@@ -19,6 +19,7 @@ def clarray(
     chunksize=5,
     second_chi_deriv=False,
     chi_func=None,
+    channel_profile=None,
 ):
     """Calculate an array of C_l(z, z').
 
@@ -69,6 +70,10 @@ def clarray(
         If `second_chi_deriv` is True, this is the function that converts
         redshift to comoving distance that is used in the finite-difference
         computation. Default: None.
+    channel_profile : function, optional
+        The frequency channel profile to use in the channel integration.
+        The profile function must be defined on [-0.5, 0.5] and integrate
+        to unity over this range. Default: None.
 
     Returns
     -------
@@ -112,6 +117,14 @@ def clarray(
             # Calculate the extended xarray with the extra intervals to integrate over
             za = (zarray[:, np.newaxis] + zhalf[:, np.newaxis] * z_r).flatten()
 
+            # If using a channel profile, evaluate it at the integrand sampling points
+            if channel_profile is not None:
+                za_profile = (
+                    np.zeros_like(zarray)[:, np.newaxis]
+                    + 0.5 * np.ones_like(zhalf)[:, np.newaxis] * z_r
+                ).flatten()
+                profile = channel_profile(za_profile)
+
             # Make array to store final results
             cla = np.zeros((lmax + 1, zlen, zlen), dtype=np.float64)
 
@@ -130,6 +143,10 @@ def clarray(
                     xarray = chi_func(za)
                     clt = diff2(clt, xarray, axis=1)
                     clt = diff2(clt, xarray, axis=2)
+
+                if channel_profile is not None:
+                    clt *= profile[np.newaxis, :, np.newaxis]
+                    clt *= profile[np.newaxis, np.newaxis, :]
 
                 # Perform Gauss-Legendre quandrature via matrix multiplications
                 clt = clt.reshape(-1, zint)
@@ -152,6 +169,14 @@ def clarray(
                 zarray[:, np.newaxis] + np.linspace(-zhalf, zhalf, zint)[np.newaxis, :]
             ).flatten()
 
+            # If using a channel profile, evaluate it at the integrand sampling points
+            if channel_profile is not None:
+                za_profile = (
+                    np.zeros_like(zarray)[:, np.newaxis]
+                    + np.linspace(-0.5, 0.5, zint)[np.newaxis, :]
+                ).flatten()
+                profile = channel_profile(za_profile)
+
             lsections = np.array_split(np.arange(lmax + 1), lmax // chunksize)
 
             cla = np.zeros((lmax + 1, zlen, zlen), dtype=np.float64)
@@ -162,6 +187,10 @@ def clarray(
                     za[np.newaxis, :, np.newaxis],
                     za[np.newaxis, np.newaxis, :],
                 )
+
+                if channel_profile is not None:
+                    clt *= profile[np.newaxis, :, np.newaxis]
+                    clt *= profile[np.newaxis, np.newaxis, :]
 
                 clt = clt.reshape(-1, zlen, zint, zlen, zint)
 

--- a/cora/core/skysim.py
+++ b/cora/core/skysim.py
@@ -20,6 +20,7 @@ def clarray(
     second_chi_deriv=False,
     chi_func=None,
     channel_profile=None,
+    channel_profile_limit=0.5,
 ):
     """Calculate an array of C_l(z, z').
 
@@ -52,7 +53,9 @@ def clarray(
         Romberg scheme. Default: False.
     zromb : integer, optional
         The Romberg or Gauss-Legendre order for integrating over
-        each channel. If 0, this integration is turned off. Default: 3.
+        each channel. If 0, this integration is turned off.
+        5 is recommended for roughly percent-level accuracy in final
+        spectrum, given CHIME frequency channels. Default: 3.
     zwidth : scalar, optional
         Constant redshift width of frequency channel to integrate over.
         If None, calculated from the separation of the first two bins
@@ -71,9 +74,15 @@ def clarray(
         redshift to comoving distance that is used in the finite-difference
         computation. Default: None.
     channel_profile : function, optional
-        The frequency channel profile to use in the channel integration.
-        The profile function must be defined on [-0.5, 0.5] and integrate
-        to unity over this range. Default: None.
+        Frequency channel profile to use in the channel integration.
+        The profile function must be defined in terms of frequency relative
+        to channel center, in units of channel width (e.g. center = 0,
+        edges = [-0.5, 0.5]). The input profile must integrate to unity
+        over the range [-channel_profile_limit, channel_profile_limit].
+        If None, a top-hat profile is used. Default: None.
+    channel_profile_limit : float, optional
+        Determines within which to integrate the channel profile.
+        Default: 0.5.
 
     Returns
     -------
@@ -83,6 +92,9 @@ def clarray(
 
     if second_chi_deriv and chi_func is None:
         raise RuntimeError("Must specify chi_func if using second_chi_deriv")
+
+    # Set coordinate rescaling factor based on channel integration limits
+    coord_scale = channel_profile_limit / 0.5
 
     if zromb == 0:
         return aps(
@@ -113,15 +125,18 @@ def clarray(
             zint = 2**zromb + 1
             z_r, z_w, z_wsum = ss.roots_legendre(zint, mu=True)
             z_w /= z_wsum
+            z_w *= coord_scale
 
             # Calculate the extended xarray with the extra intervals to integrate over
-            za = (zarray[:, np.newaxis] + zhalf[:, np.newaxis] * z_r).flatten()
+            za = (
+                zarray[:, np.newaxis] + coord_scale * zhalf[:, np.newaxis] * z_r
+            ).flatten()
 
             # If using a channel profile, evaluate it at the integrand sampling points
             if channel_profile is not None:
                 za_profile = (
                     np.zeros_like(zarray)[:, np.newaxis]
-                    + 0.5 * np.ones_like(zhalf)[:, np.newaxis] * z_r
+                    + 0.5 * coord_scale * np.ones_like(zhalf)[:, np.newaxis] * z_r
                 ).flatten()
                 profile = channel_profile(za_profile)
 
@@ -166,14 +181,19 @@ def clarray(
             zspace = 2.0 * zhalf / 2**zromb
 
             za = (
-                zarray[:, np.newaxis] + np.linspace(-zhalf, zhalf, zint)[np.newaxis, :]
+                zarray[:, np.newaxis]
+                + np.linspace(-coord_scale * zhalf, coord_scale * zhalf, zint)[
+                    np.newaxis, :
+                ]
             ).flatten()
 
             # If using a channel profile, evaluate it at the integrand sampling points
             if channel_profile is not None:
                 za_profile = (
                     np.zeros_like(zarray)[:, np.newaxis]
-                    + np.linspace(-0.5, 0.5, zint)[np.newaxis, :]
+                    + np.linspace(-channel_profile_limit, channel_profile_limit, zint)[
+                        np.newaxis, :
+                    ]
                 ).flatten()
                 profile = channel_profile(za_profile)
 
@@ -197,7 +217,7 @@ def clarray(
                 clt = si.romb(clt, dx=zspace, axis=4)
                 clt = si.romb(clt, dx=zspace, axis=2)
 
-                cla[lsec] = clt / (2 * zhalf) ** 2  # Normalise
+                cla[lsec] = clt / (2 * zhalf / coord_scale) ** 2  # Normalise
 
         return cla
 

--- a/cora/core/skysim.py
+++ b/cora/core/skysim.py
@@ -261,8 +261,7 @@ def mkconstrained(corr, constraints, nside):
 
     numz = corr.shape[1]
     maxl = corr.shape[0] - 1
-    larr, marr = healpy.Alm.getlm(maxl)
-    matshape = larr.shape + (numz,)
+    larr, _ = healpy.Alm.getlm(maxl)
 
     # The number of constraints
     nmodes = len(constraints)
@@ -291,11 +290,11 @@ def mkconstrained(corr, constraints, nside):
 
     # Solve for the eigenmode amplitudes to satisfy constraints, and project
     # each mode across the whole frequency range.
-    for i, l in enumerate(larr):
-        if l == 0:
+    for i, ell in enumerate(larr):
+        if ell == 0:
             cv[:, i] = 0.0
         else:
-            cv[:, i] = np.dot(trans[l].T, la.solve(tmat[l].T, cmap[i]))
+            cv[:, i] = np.dot(trans[ell].T, la.solve(tmat[ell].T, cmap[i]))
 
     hpmaps = np.empty((numz, healpy.nside2npix(nside)))
 

--- a/cora/signal/corr.py
+++ b/cora/signal/corr.py
@@ -888,7 +888,7 @@ class RedshiftCorrelation(object):
 
     _freq_window = 0.0
 
-    def angular_powerspectrum_fft(self, la, za1, za2):
+    def angular_powerspectrum_fft(self, la, za1, za2, const_redshift=None):
         """The angular powerspectrum C_l(z1, z2) in a flat-sky limit.
 
         Uses FFT based method to generate a lookup table for fast computation.
@@ -899,6 +899,10 @@ class RedshiftCorrelation(object):
             The multipole moments to return at.
         z1, z2 : array_like
             The redshift slices to correlate.
+        const_redshift : float, optional
+            If specified, evaluate 3d power spectrum at this redshift,
+            still using distances corresponding to z1 and z2 in conversion
+            to angular power spectrum. Default: None.
 
         Returns
         -------
@@ -944,11 +948,18 @@ class RedshiftCorrelation(object):
         xa1 = self.cosmology.comoving_distance(za1)
         xa2 = self.cosmology.comoving_distance(za2)
 
-        b1, b2 = self.bias_z(za1), self.bias_z(za2)
-        f1, f2 = self.growth_rate(za1), self.growth_rate(za2)
-        pf1, pf2 = self.prefactor(za1), self.prefactor(za2)
-        D1 = self.growth_factor(za1) / self.growth_factor(self.ps_redshift)
-        D2 = self.growth_factor(za2) / self.growth_factor(self.ps_redshift)
+        if const_redshift is not None:
+            zeval1 = const_redshift
+            zeval2 = const_redshift
+        else:
+            zeval1 = za1
+            zeval2 = za2
+
+        b1, b2 = self.bias_z(zeval1), self.bias_z(zeval2)
+        f1, f2 = self.growth_rate(zeval1), self.growth_rate(zeval2)
+        pf1, pf2 = self.prefactor(zeval1), self.prefactor(zeval2)
+        D1 = self.growth_factor(zeval1) / self.growth_factor(self.ps_redshift)
+        D2 = self.growth_factor(zeval2) / self.growth_factor(self.ps_redshift)
 
         xc = 0.5 * (xa1 + xa2)
         rpar = np.abs(xa2 - xa1)

--- a/cora/signal/corr21cm.py
+++ b/cora/signal/corr21cm.py
@@ -180,7 +180,7 @@ class Corr21cm(corr.RedshiftCorrelation, maps.Sky3d):
         return np.ones_like(z) * 1.0
 
     # Override angular_power spectrum to switch to allow using frequency
-    def angular_powerspectrum(self, l, nu1, nu2, redshift=False):
+    def angular_powerspectrum(self, l, nu1, nu2, redshift=False, const_redshift=None):
         """Calculate the angular powerspectrum.
 
         Parameters
@@ -192,6 +192,10 @@ class Corr21cm(corr.RedshiftCorrelation, maps.Sky3d):
         redshift : boolean, optional
             If `False` (default) interperet `nu1`, `nu2` as frequencies,
             otherwise they are redshifts (relative to the 21cm line).
+        const_redshift : float, optional
+            If specified, evaluate 3d power spectrum at this redshift,
+            still using distances corresponding to z1 and z2 in conversion
+            to angular power spectrum. Default: None.
 
         Returns
         -------
@@ -205,7 +209,9 @@ class Corr21cm(corr.RedshiftCorrelation, maps.Sky3d):
             z1 = nu1
             z2 = nu2
 
-        return corr.RedshiftCorrelation.angular_powerspectrum(self, l, z1, z2)
+        return corr.RedshiftCorrelation.angular_powerspectrum(
+            self, l, z1, z2, const_redshift=const_redshift
+        )
 
     # Override angular_power spectrum to switch to allow using frequency
     def angular_powerspectrum_full(self, l, nu1, nu2, redshift=False):

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -309,17 +309,18 @@ def corr_to_clarray(
     FoG_convolve: bool = False,
     FoG_sigmaP: float = None,
     FoG_kernel_max_nchannels: int = None,
+    channel_profile: Callable[[np.ndarray], np.ndarray] = None,
 ):
     r"""Calculate an array of :math:`C_\ell(\chi_1, \chi_2)`.
 
-    This routine compute the following triple integral:
+    This routine computes the following triple integral:
 
     .. math::
         C_\ell(\chi_1, \chi_2) = 2\pi \int_{-1}^1 P_\ell(\mu)
         \int d\chi_1' W_1(\chi_1') \int d\chi_2' W_2(\chi_2')
         \xi(r[\mu, \chi_1', \chi_2'])
 
-    where :math:`W_1` and :math:`W_2` are normalized top-hats centered on
+    where :math:`W_1` and :math:`W_2` are normalized channel profiles centered on
     :math:`\chi_1` and :math:`\chi_2`.
 
     Parameters
@@ -366,6 +367,10 @@ def corr_to_clarray(
         Restrict the width of the Finger-of-God kernel to the comoving distance
         interval equal to twice this number of frequency channels. This reduces
         the computational cost of the convolution.
+    channel_profile
+        Frequency channel profile to use in the channel integration.
+        The profile function must be defined on [-0.5, 0.5].
+        If None, a top-hat profile is used. Default: None.
 
     Returns
     -------
@@ -386,22 +391,29 @@ def corr_to_clarray(
     if channel_method not in ["gauss-legendre", "uniform"]:
         raise RuntimeError("channel method must be one of 'gauss-legendre', 'uniform'")
 
-    if channel_method == "gauss-legendre" and FoG_convolve:
-        raise NotImplementedError(
-            "Finger-of-God damping is not implemented for Gauss-Legendre "
-            "channel integration"
-        )
+    # Catch combinations of parameters that are not implemented
+    if channel_method == "gauss-legendre":
+        if FoG_convolve:
+            raise NotImplementedError(
+                "Finger-of-God damping is not implemented for Gauss-Legendre "
+                "channel integration"
+            )
+        if channel_profile is not None:
+            raise NotImplementedError(
+                "Integration over a nontrivial channel profile is not implemented "
+                "for Gauss-Legendre channel integration"
+            )
 
-    if channel_method == "uniform" and xromb == 0:
-        raise NotImplementedError(
-            "Need xromb > 0 if using Simpson-trapezoid channel integration scheme"
-        )
-
-    if channel_method == "uniform" and xwidth is not None:
-        raise NotImplementedError(
-            "Uniform channel width not implemented for Simpson-trapezoid "
-            "channel integration scheme"
-        )
+    elif channel_method == "uniform":
+        if xromb == 0:
+            raise NotImplementedError(
+                "Need xromb > 0 if using Simpson-trapezoid channel integration scheme"
+            )
+        if xwidth is not None:
+            raise NotImplementedError(
+                "Uniform channel width not implemented for Simpson-trapezoid "
+                "channel integration scheme"
+            )
 
     # The integration over mu will be performed by Gauss-Legendre quadrature.
     # Here we calculate the points that it will be evaluated at.
@@ -464,6 +476,31 @@ def corr_to_clarray(
             xedges[0], xedges[-1], len(xarray) * xint, endpoint=True
         )
 
+        if channel_profile is not None:
+            # Determine the channel index of each point in xarray_full
+            chan_idx = np.searchsorted(xedges, xarray_full, side="right") - 1
+            chan_idx = np.clip(chan_idx, 0, xlen - 1)
+
+            # Compute the distance of each point from the channel center,
+            # divided by the channel width
+            rel_dx_full = (xarray_full - sorted_xarray[chan_idx]) / (
+                2 * xhalf[chan_idx]
+            )
+
+            # Evaluate the channel profile at these values
+            profile_full = channel_profile(rel_dx_full)
+
+            # Integrate channel profile within each channel.
+            # (We'll use these values to normalize our final channel
+            # integrals.)
+            norm = 2 * xhalf * si.quad(channel_profile, -0.5, 0.5)[0]
+        else:
+            profile_full = None
+
+            # For top-hat profile, normalization factors are just the
+            # channel widths
+            norm = 2 * xhalf
+
         # If convolving with Finger-of-God kernel, precompute kernel
         if FoG_convolve:
 
@@ -518,19 +555,16 @@ def corr_to_clarray(
 
         # Integrate over each channel
         if channel_method == "gauss-legendre":
-
             # If xromb>0, we integrate using Gauss-Legendre quadrature,
             # implemented as a matrix multiply
             if xromb > 0:
                 corr1 = corr1.reshape(-1, xint)
                 corr1 = np.matmul(corr1, x_w).reshape(-1, xlen, xint, xlen)
                 corr1 = np.matmul(corr1.transpose(0, 1, 3, 2), x_w)
-
         else:
-
-            # If desired, convolve with Finger-of-God kernel in chi and chi'.
-            # We normalize the kernel such that it integrates to unity, by
-            # dividing by the sums computed earlier.
+            # If desired, convolve with Finger-of-God kernel in chi_1 and
+            # chi_2. We normalize the kernel such that it integrates to
+            # unity, by dividing by the sums computed earlier.
             if FoG_convolve:
                 corr1 = (
                     ssig.oaconvolve(
@@ -553,12 +587,12 @@ def corr_to_clarray(
 
             # Perform channel integrals in chi_1
             corr1 = integrate_uniform_into_bins(
-                corr1, xarray_full, xedges, axis=1, mean=True
+                corr1, xarray_full, xedges, axis=1, norm=norm, window=profile_full
             )
 
             # Perform channel integrals in chi_2
             corr1 = integrate_uniform_into_bins(
-                corr1, xarray_full, xedges, axis=2, mean=True
+                corr1, xarray_full, xedges, axis=2, norm=norm, window=profile_full
             )
 
         # Save results

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -308,6 +308,7 @@ def corr_to_clarray(
     chi2_2nd_derivative: bool = False,
     FoG_convolve: bool = False,
     FoG_sigmaP: float = None,
+    FoG_kernel_max_nchannels: int = None,
 ):
     r"""Calculate an array of :math:`C_\ell(\chi_1, \chi_2)`.
 
@@ -361,6 +362,10 @@ def corr_to_clarray(
         prior to integration. Must choose `channel_method = "uniform"`.
     FoG_sigmaP
         Finger-of-God damping scale to use in kernel.
+    FoG_kernel_max_nchannels
+        Restrict the width of the Finger-of-God kernel to the comoving distance
+        interval equal to twice this number of frequency channels. This reduces
+        the computational cost of the convolution.
 
     Returns
     -------
@@ -461,9 +466,24 @@ def corr_to_clarray(
 
         # If convolving with Finger-of-God kernel, precompute kernel
         if FoG_convolve:
-            # Make array of dchi for evaluating kernel,
-            # from -(chi_max-chi_min)/2 to (chi_max-chi_min)/2
-            dxarray = xarray_full[: len(xarray_full) // 2] - xarray_full[0]
+
+            # Compute the maximum number of |dchi| values at which to
+            # evaluate the kernel
+            if FoG_kernel_max_nchannels is None:
+                # Just use half of the full xarray
+                n_dx = len(xarray_full) // 2
+            else:
+                # Compute the maximum number of xarray_full elements
+                # corresponding to the number of padding channels,
+                # considering the higher and lower sets of padding
+                # channels
+                n_dx = max(
+                    np.sum(xarray_full < xedges[FoG_kernel_max_nchannels + 1]),
+                    np.sum(xarray_full > xedges[-FoG_kernel_max_nchannels]),
+                )
+
+            # Make array of dchi for evaluating kernel
+            dxarray = xarray_full[:n_dx] - xarray_full[0]
             dxarray = np.concatenate([-dxarray[1:][::-1], dxarray])
 
             # Evaluate kernel, and downselect to nonzero elements.

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -309,6 +309,7 @@ def corr_to_clarray(
     chi2_2nd_derivative: bool = False,
     FoG_convolve: bool = False,
     FoG_sigmaP: float = None,
+    FoG_sigmaP_other: float = None,
     FoG_kernel_max_nchannels: int = None,
     channel_profile: Callable[[np.ndarray], np.ndarray] = None,
     overlapping_channels: int = 0,
@@ -365,6 +366,9 @@ def corr_to_clarray(
         prior to integration. Must choose `channel_method = "uniform"`.
     FoG_sigmaP
         Finger-of-God damping scale to use in kernel.
+    FoG_sigmaP_other
+        Finger-of-God damping scale to use in kernel corresponding to `chi_2`.
+        If None, `FoG_sigmaP` is used for both `chi_1` and `chi_2`.
     FoG_kernel_max_nchannels
         Restrict the width of the Finger-of-God kernel to the comoving distance
         interval equal to twice this number of frequency channels. This reduces
@@ -551,6 +555,19 @@ def corr_to_clarray(
                 mode="same",
             )
 
+            # If FoG_sigmaP_other is specified, evaluate corresponding kernel
+            if FoG_sigmaP_other is not None:
+                FoG_kernel_other = exponential_FoG_kernel_1d(dxarray, FoG_sigmaP_other)
+                FoG_kernel_other = FoG_kernel_other[FoG_kernel_other > 0.0]
+                FoG_kernel_other_norm = ssig.oaconvolve(
+                    np.ones_like(xarray_full),
+                    FoG_kernel_other,
+                    mode="same",
+                )
+            else:
+                FoG_kernel_other = FoG_kernel
+                FoG_kernel_other_norm = FoG_kernel_norm
+
     # Split mu values into chunks, to avoid memory usage blowing up
     for msec in np.array_split(np.arange(_len), _len // chunksize):
         # Index into the global index in mu, and evaluate the correlation
@@ -591,11 +608,11 @@ def corr_to_clarray(
                 corr1 = (
                     ssig.oaconvolve(
                         corr1,
-                        FoG_kernel[np.newaxis, np.newaxis, :],
+                        FoG_kernel_other[np.newaxis, np.newaxis, :],
                         axes=(2,),
                         mode="same",
                     )
-                    / FoG_kernel_norm[..., :]
+                    / FoG_kernel_other_norm[..., :]
                 )
 
             # Perform channel integrals in chi_1, then chi_2

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -675,7 +675,7 @@ def ps_to_aps_flat(
     n_k: int = 0,
     n_mu: int = 0,
 ) -> Callable[[np.ndarray, np.ndarray, np.ndarray], np.ndarray]:
-    """Calculate a multi-distance angular power spectrum from a 3D power spectrum.
+    r"""Calculate a multi-distance angular power spectrum from a 3D power spectrum.
 
     This uses a flat sky limit. See equation 21 of arXiv:astro-ph/0605546.
 

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -291,7 +291,7 @@ def legendre_array(lmax: int, mu: np.ndarray) -> np.ndarray:
     lm = np.zeros((lmax + 1, len(mu)), dtype=np.float64)
 
     for i, v in enumerate(mu):
-        lm[:, i] = ss.lpn(lmax, v)[0]
+        lm[:, i] = ss.legendre_p_all(lmax, v, diff_n=1)[0]
 
     return lm
 

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -1,8 +1,9 @@
-from typing import Callable, Union, Optional, Tuple, List
+from typing import Callable, Union, Tuple, List
 
 import numpy as np
 import scipy.integrate as si
 import scipy.special as ss
+import scipy.ndimage as sn
 from scipy.fftpack import dct
 
 from caput import mpiarray
@@ -15,7 +16,12 @@ import pyfftlog
 from ..util import bilinearmap
 from ..util.nputil import FloatArrayLike
 
-from .lssutil import diff2
+from .lssutil import (
+    diff2,
+    calculate_width,
+    integrate_uniform_into_bins,
+    exponential_FoG_kernel_1d,
+)
 
 
 def richardson(
@@ -294,108 +300,251 @@ def corr_to_clarray(
     lmax: int,
     xarray: np.ndarray,
     xromb: int = 3,
-    xwidth: Optional[float] = None,
+    xwidth: float = None,
     q: int = 2,
     chunksize: int = 50,
+    channel_method: str = "gauss-legendre",
     chi1_2nd_derivative: bool = False,
     chi2_2nd_derivative: bool = False,
+    FoG_convolve: bool = False,
+    FoG_sigmaP: float = None,
 ):
-    """Calculate an array of :math:`C_l(\chi_1, \chi_2)`.
+    r"""Calculate an array of :math:`C_\ell(\chi_1, \chi_2)`.
+
+    This routine compute the following triple integral:
+
+    .. math::
+        C_\ell(\chi_1, \chi_2) = 2\pi \int_{-1}^1 P_\ell(\mu)
+        \int d\chi_1' W_1(\chi_1') \int d\chi_2' W_2(\chi_2')
+        \xi(r[\mu, \chi_1', \chi_2'])
+
+    where :math:`W_1` and :math:`W_2` are normalized top-hats centered on
+    :math:`\chi_1` and :math:`\chi_2`.
 
     Parameters
     ----------
     corr
         The real space correlation function.
-    c
-        The cosmology object.
     lmax
-        Maximum l to calculate up to.
+        Maximum ell to calculate up to.
     xarray
         Array of comoving distances to calculate at.
     xromb
-        The order for integrating over radial bins, uses `2**xromb + 1` points. This
-        generates an exponentially increasing amount of work, so increase carefully.
-        Note that despite the parameter name this no longer uses a Romberg integrator,
-        but a Gauss-Legendre quadrature rule.
+        The order for integrating within radial bins, related to the number of samples
+        within each bin by `2**xromb + 1`. This generates an exponentially increasing
+        amount of work, so increase carefully. Note that despite the parameter name
+        this no longer uses a Romberg integrator, but either a Gauss-Legendre
+        quadrature rule or a combination of Simpson's rule and the trapezoid rule,
+        depending on `channel_method`.
     xwidth
-        Width of radial bin to integrate over. If None (default),
-        calculate from the separation of the first two bins.
+        Assume each radial bin has this width when integrating. If None (default),
+        use nonuniform bin width determined from `xarray`.
     q
-        Integration accuracy parameter for the Legendre transform
+        Integration accuracy parameter for the integral over mu. The number of mu
+        samples is equal to `q * lmax`.
     chunksize
         Chunk size for evaluating discrete samples of angular integrand in batches.
         Default: 50.
+    channel_method
+        Method for integrating within radial bins: Gauss-Legendre quadrature
+        ("gauss-legendre") or a combination of Simpson's rule and the trapezoid rule
+        ("uniform") based on uniform sampling of the entire comoving-distance
+        range being considered. (The latter is needed for Finger-of-God damping
+        to be incorporated.)
     chi1_2nd_derivative, chi2_2nd_derivative
-        Whether to take finite-differenced 2nd derivatives of the integrand in chi_1
+        Whether to take finite-difference 2nd derivatives of the integrand in chi_1
         or chi_2 prior to integrating. This is useful for computing angular power
         spectra involving the Kaiser redshift-space distortion term by
-        differentiating power spectra involving the gravitational potential.
+        differentiating power spectra of the gravitational potential.
+    FoG_convolve
+        Whether to convolve the integrand with the Finger-of-God damping kernel
+        prior to integration. Must choose `channel_method = "uniform"`.
+    FoG_sigmaP
+        Finger-of-God damping scale to use in kernel.
 
     Returns
     -------
     clxx
-        Array of the :math:`C_l(\chi_1, \chi_2)` values, with l as the first axis.
+        Array of the :math:`C_\ell(\chi_1, \chi_2)` values, with l as the first axis.
+
+    Notes
+    -----
+    The integration scheme over radial bins evaluates a point at :math:`\xi(r=0)`,
+    which can have an outsized influence for very blue input power spectra, because
+    the number of samples in the integration is quite small and the correlation
+    function can diverge quite strongly as :math:`r \to 0`. While this could
+    make a difference in the point variance, in practice this doesn't seem to make
+    much difference to the output maps, as the transform from :math:`\theta \to \ell`
+    seems to wash out this impact.
     """
 
-    # The integration over angle will be performed by Gauss-Legendre integration. Here
-    # we calculate the points that it will be evaluated at....
+    if channel_method not in ["gauss-legendre", "uniform"]:
+        raise RuntimeError("channel method must be one of 'gauss-legendre', 'uniform'")
+
+    if channel_method == "gauss-legendre" and FoG_convolve:
+        raise NotImplementedError(
+            "Finger-of-God damping is not implemented for Gauss-Legendre "
+            "channel integration"
+        )
+
+    if channel_method == "uniform" and xromb == 0:
+        raise NotImplementedError(
+            "Need xromb > 0 if using Simpson-trapezoid channel integration scheme"
+        )
+
+    if channel_method == "uniform" and xwidth is not None:
+        raise NotImplementedError(
+            "Uniform channel width not implemented for Simpson-trapezoid "
+            "channel integration scheme"
+        )
+
+    # The integration over mu will be performed by Gauss-Legendre quadrature.
+    # Here we calculate the points that it will be evaluated at.
     M = q * lmax
     mu, w, wsum = ss.roots_legendre(M, mu=True)
 
-    # If xromb > 0 we need to integrate over the radial bin width, start by modifying
-    # the array of distances to add extra points over which we'll integrate
-    #
-    # NOTE: the integration scheme over radial bins evaluates a point at C(r=0) which
-    # can have an outsized influence for very blue input power spectra because the
-    # number of samples in the integration is quite small and the correlation function
-    # can diverge quite strongly as r->0. While this could make a difference in the
-    # point variance, in practice this doesn't seem to make much difference to the
-    # *output* maps as it the transform from theta -> l seems to wash it out
-    if xromb > 0:
-        # Calculate the half bin width
-        if xwidth is None:
-            xhalf = np.ndarray(shape=xarray.shape)
-            # width for first and second bin are same
-            xhalf[0] = np.abs(xarray[1] - xarray[0]) / 2.0
-            xhalf[1:] = np.abs(xarray[1:] - xarray[:-1]) / 2.0
-        else:
-            # for continuity with previous convention of allowing to choose xwidth
-            xhalf = np.ones(shape=xarray.shape) * xwidth / 2.0
-
-        xint = 2**xromb + 1
-
-        # Get the quadrature points and weights.
-        x_r, x_w, x_wsum = ss.roots_legendre(xint, mu=True)
-        x_w /= x_wsum
-
-        # Calculate the extended z-array with the extra intervals to integrate over
-        xa = (xarray[:, np.newaxis] + xhalf[:, np.newaxis] * x_r).flatten()
-
+    # Some of the logic below depends on xarray being in increasing order,
+    # so if it's not, we operate on a reversed version and then reverse
+    # the final results at the end
+    sorted_xarray = np.sort(xarray)
+    if np.array_equal(xarray, sorted_xarray):
+        flipped_xarray = False
+    elif np.array_equal(xarray[::-1], sorted_xarray):
+        flipped_xarray = True
     else:
-        xa = xarray
+        raise RuntimeError("xarray must be strictly increasing or decreasing")
 
+    # Make MPIArray to store channel-integrated correlation function
     xlen = xarray.size
     corr_array = mpiarray.zeros((M, xlen, xlen), axis=0)
     clo = corr_array.local_offset[0]
     _len = corr_array.local_array.shape[0]
 
-    # Split thetas into chunks, otherwise memory will blow up
-    for msec in np.array_split(np.arange(_len), _len // chunksize):
-        # Index into the global index in mu
-        rc = coordinates.spherical.cosine_rule(mu[clo + msec], xa, xa)
-        corr1 = corr(rc)
-        if chi1_2nd_derivative:
-            corr1 = diff2(corr1, xa, axis=1)
-        if chi2_2nd_derivative:
-            corr1 = diff2(corr1, xa, axis=2)
+    # Determine full set of chi values for integrand
+    if channel_method == "gauss-legendre":
 
-        # If xromb then we need to integrate over the redshift bins which we do using
-        # Gauss-Legendre quadrature implemented as a matrix multiply
         if xromb > 0:
-            corr1 = corr1.reshape(-1, xint)
-            corr1 = np.matmul(corr1, x_w).reshape(-1, xlen, xint, xlen)
-            corr1 = np.matmul(corr1.transpose(0, 1, 3, 2), x_w)
+            # Calculate the half bin width
+            if xwidth is None:
+                xhalf = 0.5 * calculate_width(sorted_xarray)
+            else:
+                xhalf = np.ones(shape=xarray.shape) * xwidth / 2.0
 
+            xint = 2**xromb + 1
+
+            # Get the quadrature points and weights
+            x_r, x_w, x_wsum = ss.roots_legendre(xint, mu=True)
+            x_w /= x_wsum
+
+            # Calculate the extended chi array, with the extra intervals
+            # to integrate over
+            xarray_full = (
+                sorted_xarray[:, np.newaxis] + xhalf[:, np.newaxis] * x_r
+            ).flatten()
+
+        else:
+            xarray_full = sorted_xarray
+
+    else:
+
+        # Determine half-channel widths and channel boundaries in chi
+        xhalf = 0.5 * calculate_width(sorted_xarray)
+        xedges = np.concatenate(
+            [sorted_xarray - xhalf, [sorted_xarray[-1] + xhalf[-1]]]
+        )
+
+        # Generate uniformly-spaced array of chi values over full chi range
+        xint = 2**xromb + 1
+        xarray_full = np.linspace(
+            xedges[0], xedges[-1], len(xarray) * xint, endpoint=True
+        )
+
+        # If convolving with Finger-of-God kernel, precompute kernel
+        if FoG_convolve:
+            # Make array of dchi for evaluating kernel,
+            # from -(chi_max-chi_min)/2 to (chi_max-chi_min)/2
+            dxarray = xarray_full[: len(xarray_full) // 2] - xarray_full[0]
+            dxarray = np.concatenate([-dxarray[1:][::-1], dxarray])
+
+            # Evaluate kernel, and downselect to nonzero elements.
+            # (Some elements may be zero due to small-value truncation
+            # within exponential_FoG_kernel_1d.)
+            FoG_kernel = exponential_FoG_kernel_1d(dxarray, FoG_sigmaP)
+            FoG_kernel = FoG_kernel[FoG_kernel > 0.0]
+
+            # Compute sum of kernel values that will be used in convolution
+            # at every element of xarray_full. This will be used to normalize
+            # the kernel later.
+            FoG_kernel_norm = sn.convolve1d(
+                np.ones_like(xarray_full),
+                weights=FoG_kernel,
+                mode="constant",
+                cval=0.0,
+            )
+
+    # Split mu values into chunks, to avoid memory usage blowing up
+    for msec in np.array_split(np.arange(_len), _len // chunksize):
+        # Index into the global index in mu, and evaluate the correlation
+        # function at the relevant (mu,chi_1,chi_2) values
+        rc = coordinates.spherical.cosine_rule(mu[clo + msec], xarray_full, xarray_full)
+        corr1 = corr(rc)
+
+        # If desired, compute second derivatives in chi_1 and/or chi_2.
+        # (Numerical stability is better if this is done before the FoG
+        # convolution rather than after.)
+        if chi1_2nd_derivative:
+            corr1 = diff2(corr1, xarray_full, axis=1)
+        if chi2_2nd_derivative:
+            corr1 = diff2(corr1, xarray_full, axis=2)
+
+        # Integrate over each channel
+        if channel_method == "gauss-legendre":
+
+            # If xromb>0, we integrate using Gauss-Legendre quadrature,
+            # implemented as a matrix multiply
+            if xromb > 0:
+                corr1 = corr1.reshape(-1, xint)
+                corr1 = np.matmul(corr1, x_w).reshape(-1, xlen, xint, xlen)
+                corr1 = np.matmul(corr1.transpose(0, 1, 3, 2), x_w)
+
+        else:
+
+            # If desired, convolve with Finger-of-God kernel in chi and chi'.
+            # We normalize the kernel such that it integrates to unity, by
+            # dividing by the sums computed earlier.
+            if FoG_convolve:
+                corr1 = (
+                    sn.convolve1d(
+                        corr1,
+                        weights=FoG_kernel,
+                        axis=1,
+                        mode="constant",
+                        cval=0.0,
+                    )
+                    / FoG_kernel_norm[np.newaxis, :, np.newaxis]
+                )
+                corr1 = (
+                    sn.convolve1d(
+                        corr1,
+                        weights=FoG_kernel,
+                        axis=2,
+                        mode="constant",
+                        cval=0.0,
+                    )
+                    / FoG_kernel_norm[..., :]
+                )
+
+            # Perform channel integrals in chi_1
+            corr1 = integrate_uniform_into_bins(
+                corr1, xarray_full, xedges, axis=1, mean=True
+            )
+
+            # Perform channel integrals in chi_2
+            corr1 = integrate_uniform_into_bins(
+                corr1, xarray_full, xedges, axis=2, mean=True
+            )
+
+        # Save results
         corr_array.local_array[msec] = corr1
 
     # Perform the dot product split over ranks for
@@ -407,10 +556,17 @@ def corr_to_clarray(
     # perform the dot product
     corr_array = corr_array.reshape(None, -1).redistribute(axis=1)
 
+    # Carry out Gauss-Legendre integration over mu, via matrix multiplication
     clxx = np.dot(lm, corr_array.local_array)
     clxx = mpiarray.MPIArray.wrap(clxx, axis=1).redistribute(axis=0)
+    clxx = clxx.reshape(None, xlen, xlen)
 
-    return clxx.reshape(None, xlen, xlen)
+    # If we reversed the input order of xarray, reverse the x axes
+    # in the final output
+    if flipped_xarray:
+        clxx = clxx[:, ::-1, ::-1]
+
+    return clxx
 
 
 def ps_to_aps_flat(

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -338,9 +338,7 @@ def corr_to_clarray(
         The order for integrating within radial bins, related to the number of samples
         within each bin by `2**xromb + 1`. This generates an exponentially increasing
         amount of work, so increase carefully. Note that despite the parameter name
-        this no longer uses a Romberg integrator, but either a Gauss-Legendre
-        quadrature rule or a combination of Simpson's rule and the trapezoid rule,
-        depending on `channel_method`.
+        this no longer uses a Romberg integrator; see `channel_method` for details.
     xwidth
         Assume each radial bin has this width when integrating. If None (default),
         use nonuniform bin width determined from `xarray`.
@@ -351,11 +349,13 @@ def corr_to_clarray(
         Chunk size for evaluating discrete samples of angular integrand in batches.
         Default: 50.
     channel_method
-        Method for integrating within radial bins: Gauss-Legendre quadrature
-        ("gauss-legendre") or a combination of Simpson's rule and the trapezoid rule
-        ("uniform") based on uniform sampling of the entire comoving-distance
-        range being considered. (The latter is needed for Finger-of-God damping
-        to be incorporated.)
+        Method for integrating within radial bins:
+        - "gauss-legendre": Gauss-Legendre quadrature
+        - "uniform": uses uniform sampling of the entire comoving-distance range
+        being considered. Uses a combination of Simpson's rule and the trapezoid
+        rule if `overlapping_channels` is `False` (see below), or Simpson's rule
+        if `overlapping_channels` is `True`. ("uniform is needed for Finger-of-God
+        damping to be incorporated.)
     chi1_2nd_derivative, chi2_2nd_derivative
         Whether to take finite-difference 2nd derivatives of the integrand in chi_1
         or chi_2 prior to integrating. This is useful for computing angular power

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -15,6 +15,8 @@ import pyfftlog
 from ..util import bilinearmap
 from ..util.nputil import FloatArrayLike
 
+from .lssutil import diff2
+
 
 def richardson(
     estimates: List[FloatArrayLike],
@@ -295,6 +297,8 @@ def corr_to_clarray(
     xwidth: Optional[float] = None,
     q: int = 2,
     chunksize: int = 50,
+    chi1_2nd_derivative: bool = False,
+    chi2_2nd_derivative: bool = False,
 ):
     """Calculate an array of :math:`C_l(\chi_1, \chi_2)`.
 
@@ -321,6 +325,11 @@ def corr_to_clarray(
     chunksize
         Chunk size for evaluating discrete samples of angular integrand in batches.
         Default: 50.
+    chi1_2nd_derivative, chi2_2nd_derivative
+        Whether to take finite-differenced 2nd derivatives of the integrand in chi_1
+        or chi_2 prior to integrating. This is useful for computing angular power
+        spectra involving the Kaiser redshift-space distortion term by
+        differentiating power spectra involving the gravitational potential.
 
     Returns
     -------
@@ -375,6 +384,10 @@ def corr_to_clarray(
         # Index into the global index in mu
         rc = coordinates.spherical.cosine_rule(mu[clo + msec], xa, xa)
         corr1 = corr(rc)
+        if chi1_2nd_derivative:
+            corr1 = diff2(corr1, xa, axis=1)
+        if chi2_2nd_derivative:
+            corr1 = diff2(corr1, xa, axis=2)
 
         # If xromb then we need to integrate over the redshift bins which we do using
         # Gauss-Legendre quadrature implemented as a matrix multiply

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -20,6 +20,7 @@ from .lssutil import (
     diff2,
     calculate_width,
     integrate_uniform_into_bins,
+    integrate_uniform_into_tapered_channels,
     exponential_FoG_kernel_1d,
 )
 
@@ -310,6 +311,7 @@ def corr_to_clarray(
     FoG_sigmaP: float = None,
     FoG_kernel_max_nchannels: int = None,
     channel_profile: Callable[[np.ndarray], np.ndarray] = None,
+    overlapping_channels: int = 0,
 ):
     r"""Calculate an array of :math:`C_\ell(\chi_1, \chi_2)`.
 
@@ -369,8 +371,15 @@ def corr_to_clarray(
         the computational cost of the convolution.
     channel_profile
         Frequency channel profile to use in the channel integration.
-        The profile function must be defined on [-0.5, 0.5].
-        If None, a top-hat profile is used. Default: None.
+        The profile function must be defined in terms of frequency relative
+        to channel center, in units of channel width (e.g. center = 0,
+        edges = [-0.5, 0.5]). If None, a top-hat profile is used.
+        Default: None.
+    overlapping_channels
+        If > 0, use a special algorithm that integrates the channel profile
+        over this number of neighboring channels on either side of the channel
+        of interest, to capture contributions from the channel profile that
+        extend beyond the nominal channel boundaries. Default: 0.
 
     Returns
     -------
@@ -476,7 +485,11 @@ def corr_to_clarray(
             xedges[0], xedges[-1], len(xarray) * xint, endpoint=True
         )
 
-        if channel_profile is not None:
+        # If we're using a channel profile with overlap of neighboring channels,
+        # we'll use a routine that accepts the profile function as an argument.
+        # If our profile has no overlap, we need to precompute some profile
+        # quantities here.
+        if channel_profile is not None and overlapping_channels == 0:
             # Determine the channel index of each point in xarray_full
             chan_idx = np.searchsorted(xedges, xarray_full, side="right") - 1
             chan_idx = np.clip(chan_idx, 0, xlen - 1)
@@ -585,15 +598,35 @@ def corr_to_clarray(
                     / FoG_kernel_norm[..., :]
                 )
 
-            # Perform channel integrals in chi_1
-            corr1 = integrate_uniform_into_bins(
-                corr1, xarray_full, xedges, axis=1, norm=norm, window=profile_full
-            )
-
-            # Perform channel integrals in chi_2
-            corr1 = integrate_uniform_into_bins(
-                corr1, xarray_full, xedges, axis=2, norm=norm, window=profile_full
-            )
+            # Perform channel integrals in chi_1, then chi_2
+            if overlapping_channels == 0:
+                corr1 = integrate_uniform_into_bins(
+                    corr1, xarray_full, xedges, axis=1, norm=norm, window=profile_full
+                )
+                corr1 = integrate_uniform_into_bins(
+                    corr1, xarray_full, xedges, axis=2, norm=norm, window=profile_full
+                )
+            else:
+                corr1 = integrate_uniform_into_tapered_channels(
+                    corr1,
+                    xarray_full,
+                    sorted_xarray,
+                    2 * xhalf,
+                    channel_profile,
+                    axis=1,
+                    n_overlap=overlapping_channels,
+                    use_cached_weights=True,
+                )
+                corr1 = integrate_uniform_into_tapered_channels(
+                    corr1,
+                    xarray_full,
+                    sorted_xarray,
+                    2 * xhalf,
+                    channel_profile,
+                    axis=2,
+                    n_overlap=overlapping_channels,
+                    use_cached_weights=True,
+                )
 
         # Save results
         corr_array.local_array[msec] = corr1

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -3,7 +3,7 @@ from typing import Callable, Union, Tuple, List
 import numpy as np
 import scipy.integrate as si
 import scipy.special as ss
-import scipy.ndimage as sn
+import scipy.signal as ssig
 from scipy.fftpack import dct
 
 from caput import mpiarray
@@ -495,11 +495,10 @@ def corr_to_clarray(
             # Compute sum of kernel values that will be used in convolution
             # at every element of xarray_full. This will be used to normalize
             # the kernel later.
-            FoG_kernel_norm = sn.convolve1d(
+            FoG_kernel_norm = ssig.oaconvolve(
                 np.ones_like(xarray_full),
-                weights=FoG_kernel,
-                mode="constant",
-                cval=0.0,
+                FoG_kernel,
+                mode="same",
             )
 
     # Split mu values into chunks, to avoid memory usage blowing up
@@ -534,22 +533,20 @@ def corr_to_clarray(
             # dividing by the sums computed earlier.
             if FoG_convolve:
                 corr1 = (
-                    sn.convolve1d(
+                    ssig.oaconvolve(
                         corr1,
-                        weights=FoG_kernel,
-                        axis=1,
-                        mode="constant",
-                        cval=0.0,
+                        FoG_kernel[np.newaxis, :, np.newaxis],
+                        axes=(1,),
+                        mode="same",
                     )
                     / FoG_kernel_norm[np.newaxis, :, np.newaxis]
                 )
                 corr1 = (
-                    sn.convolve1d(
+                    ssig.oaconvolve(
                         corr1,
-                        weights=FoG_kernel,
-                        axis=2,
-                        mode="constant",
-                        cval=0.0,
+                        FoG_kernel[np.newaxis, np.newaxis, :],
+                        axes=(2,),
+                        mode="same",
                     )
                     / FoG_kernel_norm[..., :]
                 )

--- a/cora/signal/corrfunc.py
+++ b/cora/signal/corrfunc.py
@@ -428,6 +428,10 @@ def corr_to_clarray(
                 "channel integration scheme"
             )
 
+    # If no damping scale is supplied, don't do any FoG convolution
+    if FoG_sigmaP is None:
+        FoG_convolve = False
+
     # The integration over mu will be performed by Gauss-Legendre quadrature.
     # Here we calculate the points that it will be evaluated at.
     M = q * lmax

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -2107,8 +2107,9 @@ class AddCorrelatedShotNoise(tasklib.random.RandomTask, tasklib.base.ContainerTa
 
         chi_local_bounds = input_field.delta[:].local_bounds
         ichi = input_field.chi[chi_local_bounds]
+        ichi_width = lssutil.calculate_width(input_field.chi)[chi_local_bounds]
 
-        volume = pixarea * (ichi**2) * lssutil.calculate_width(ichi)
+        volume = pixarea * ichi**2 * ichi_width
 
         std = (volume * self._n_eff_z[chi_local_bounds]) ** -0.5
         shot_noise = self.rng.normal(

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -435,6 +435,20 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     FoG_freq_padding_threshold = config.Property(proptype=float, default=0.99)
     FoG_freq_padding_maxnum = config.Property(proptype=int, default=None)
 
+    def setup(self, profile_cont: Optional[InterpolatedFunction] = None):
+        """Set up frequency channel profile.
+
+        Parameters
+        ----------
+        profile_cont: InterpolatedFunction, optional
+            `InterpolatedFunction` container with frequency channel profile.
+            If None, a top-hat is used. Default: None.
+        """
+
+        self.channel_profile_func = None
+        if profile_cont is not None:
+            self.channel_profile_func = profile_cont.get_function("profile")
+
     def process(
         self, correlation_functions: CorrelationFunction
     ) -> MultiFrequencyAngularPowerSpectrum:
@@ -567,6 +581,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             FoG_convolve=self.FoG_convolve,
             FoG_sigmaP=sigma_P,
             FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+            channel_profile=self.channel_profile_func,
         )
 
         self.log.debug(f"Generating C_l(x, x') for {phi_label}-delta")
@@ -581,6 +596,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             FoG_convolve=self.FoG_convolve,
             FoG_sigmaP=sigma_P,
             FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+            channel_profile=self.channel_profile_func,
             chi1_2nd_derivative=self.use_d2phi,
         )
 
@@ -596,6 +612,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             FoG_convolve=self.FoG_convolve,
             FoG_sigmaP=sigma_P,
             FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+            channel_profile=self.channel_profile_func,
             chi1_2nd_derivative=self.use_d2phi,
             chi2_2nd_derivative=self.use_d2phi,
         )

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -407,6 +407,9 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     FoG_freq_padding_maxnum : int, optional
         Maximum number of frequencies to pad by (to limit the maximum computational
         cost). Default: None.
+    overlapping_channels : int, optional
+        If using frequency channel profile, number of neighboring channels
+        to integrate over to capture tails of profile. Default: 0.
     """
 
     nside = config.Property(proptype=int)
@@ -434,6 +437,8 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     FoG_z_eval = config.Property(proptype=float, default=None)
     FoG_freq_padding_threshold = config.Property(proptype=float, default=0.99)
     FoG_freq_padding_maxnum = config.Property(proptype=int, default=None)
+
+    overlapping_channels = config.Property(proptype=int, default=0)
 
     def setup(self, profile_cont: Optional[InterpolatedFunction] = None):
         """Set up frequency channel profile.
@@ -582,6 +587,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             FoG_sigmaP=sigma_P,
             FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
             channel_profile=self.channel_profile_func,
+            overlapping_channels=self.overlapping_channels,
         )
 
         self.log.debug(f"Generating C_l(x, x') for {phi_label}-delta")
@@ -597,6 +603,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             FoG_sigmaP=sigma_P,
             FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
             channel_profile=self.channel_profile_func,
+            overlapping_channels=self.overlapping_channels,
             chi1_2nd_derivative=self.use_d2phi,
         )
 
@@ -613,6 +620,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             FoG_sigmaP=sigma_P,
             FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
             channel_profile=self.channel_profile_func,
+            overlapping_channels=self.overlapping_channels,
             chi1_2nd_derivative=self.use_d2phi,
             chi2_2nd_derivative=self.use_d2phi,
         )

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -1122,6 +1122,11 @@ class FingersOfGod(tasklib.base.ContainerTask):
         prior to applying the FoG kernel, and then reapplied afterwards. This should
         be done for a cosmological density field, but not for a shot-noise field.
         Default: True.
+    use_full_channel_kernel : bool
+        Whether to integrate the continuous FoG kernel over each radial bin for both
+        the "input" and "output" channel (True), or just the "input" channel
+        (False). The former is more correct, but the latter is the default for
+        legacy purposes. Default. False.
     """
 
     model = config.enum(lssmodels.sigma_P.models(), default=None)
@@ -1132,6 +1137,8 @@ class FingersOfGod(tasklib.base.ContainerTask):
     z_eff = config.Property(proptype=float, default=None)
 
     apply_growth_factor = config.Property(proptype=bool, default=True)
+
+    use_full_channel_kernel = config.Property(proptype=bool, default=False)
 
     def setup(self, cosmo_cont: Optional[containers.CosmologyContainer] = None):
         """Verify the config parameters and initialize cosmology."""
@@ -1195,7 +1202,12 @@ class FingersOfGod(tasklib.base.ContainerTask):
             D = np.full(redshift.shape, 1.0)
         sigmaP = self._sigma_P(redshift)
 
-        K = lssutil.exponential_FoG_kernel(chi, self.alpha_FoG * sigmaP, D)
+        K = lssutil.exponential_FoG_kernel(
+            chi,
+            self.alpha_FoG * sigmaP,
+            D,
+            full_channel_kernel=self.use_full_channel_kernel,
+        )
 
         smoothed_field = field.__class__(axes_from=field, attrs_from=field)
         # Distribute over pixels to apply the smoothing kernel

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -857,7 +857,16 @@ class ZeldovichDynamics(DynamicsBase):
 
 
 class LinearDynamics(DynamicsBase):
-    """Generate a simulated LSS field using first order standard perturbation theory."""
+    """Generate a simulated LSS field using first order standard perturbation theory.
+
+    Attributes
+    ----------
+    output_kaiser_only : bool
+        Only save the Kaiser velocity term instead of the full field. (Useful for
+        testing.) Default: False.
+    """
+
+    output_kaiser_only = config.Property(proptype=bool, default=False)
 
     def process(self, initial_field: InitialLSS, biased_field: BiasedLSS) -> BiasedLSS:
         """Apply Eulerian linear dynamics to the biased field to get the final field.
@@ -911,7 +920,10 @@ class LinearDynamics(DynamicsBase):
             vterm = lssutil.diff2(iphi, chi[:], axis=0)
             vterm *= -(D * fr)[:, np.newaxis]
 
-            fdelta[:] += vterm
+            if self.output_kaiser_only:
+                fdelta[:] = vterm[:]
+            else:
+                fdelta[:] += vterm
 
         final_field.redistribute("chi")
 

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -249,6 +249,13 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     The output will be evaluated at constant redshift, corresponding
     to the redshift of the input correlation functions.
 
+    Spectra will be calculated for delta-delta, phi-delta, and phi-phi,
+    where delta is the matter overdensity and phi is the gravitational
+    potential (including numerical prefactors from the Poisson equation).
+    If `use_d2phi` is set, the second line-of-sight derivative of phi
+    will be used instead of phi. (This is useful to simulating maps of
+    the Kaiser redshift-space distortion term.)
+
     Attributes
     ----------
     nside : int
@@ -269,13 +276,16 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
         computation. When dealing with nonlinear matter power spectrum,
         for sub-percent accuracy up to l ~ 1500, leg_q = 16 is recommended.
         Default: 4.
-    leg_chunksize: int, optional
+    leg_chunksize : int, optional
         Chunk size for evaluating samples of C_ell integrand. Changing
         from default value is unlikely to affect performance. Default: 50.
-    corrfunc_interp_type: str, optional
+    corrfunc_interp_type : str, optional
         Interpolation method to use for correlation function in C_ell
         integrand. If None, the default method stored in the
         CorrelationFunction container is used. Default: None.
+    use_d2phi : bool, optional
+        Compute spectra corresponding to the second line-of-sight
+        derivative of phi instead of phi itself. Default: False.
     """
 
     nside = config.Property(proptype=int)
@@ -285,6 +295,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     leg_q = config.Property(proptype=int, default=4)
     leg_chunksize = config.Property(proptype=int, default=50)
     corrfunc_interp_type = config.enum(_INTERP_TYPES, default=None)
+    use_d2phi = config.Property(proptype=bool, default=False)
 
     def process(
         self, correlation_functions: CorrelationFunction
@@ -323,6 +334,8 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
         # power will alias back down when the map is transformed later on
         lmax = 3 * self.nside - 1
 
+        phi_label = "d2phi" if self.use_d2phi else "phi"
+
         self.log.debug("Generating C_l(x, x') for delta-delta")
         cla0 = corrfunc.corr_to_clarray(
             corr0,
@@ -333,7 +346,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             chunksize=self.leg_chunksize,
         )
 
-        self.log.debug("Generating C_l(x, x') for phi-delta")
+        self.log.debug(f"Generating C_l(x, x') for {phi_label}-delta")
         cla2 = corrfunc.corr_to_clarray(
             corr2,
             lmax,
@@ -341,9 +354,10 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             xromb=self.xromb,
             q=self.leg_q,
             chunksize=self.leg_chunksize,
+            chi1_2nd_derivative=self.use_d2phi,
         )
 
-        self.log.debug("Generating C_l(x, x') for phi-phi")
+        self.log.debug(f"Generating C_l(x, x') for {phi_label}-{phi_label}")
         cla4 = corrfunc.corr_to_clarray(
             corr4,
             lmax,
@@ -351,6 +365,8 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             xromb=self.xromb,
             q=self.leg_q,
             chunksize=self.leg_chunksize,
+            chi1_2nd_derivative=self.use_d2phi,
+            chi2_2nd_derivative=self.use_d2phi,
         )
 
         if self.frequencies is not None:
@@ -358,12 +374,14 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
                 cosmology=cosmology,
                 freq=self.frequencies,
                 lmax=lmax,
+                d2phi=self.use_d2phi,
             )
         else:
             out_cont = MultiFrequencyAngularPowerSpectrum(
                 cosmology=cosmology,
                 redshift=redshift,
                 lmax=lmax,
+                d2phi=self.use_d2phi,
             )
 
         out_cont.Cl_delta_delta[:] = cla0
@@ -441,7 +459,7 @@ class GenerateInitialLSSFromCl(tasklib.base.ContainerTask):
         cla = mpiarray.zeros((len(self.aps.ell), 2 * nz, 2 * nz), axis=0)
         cla[:, nz:, nz:] = self.aps.Cl_delta_delta[:]
         cla[:, :nz, nz:] = self.aps.Cl_phi_delta[:]
-        cla[:, nz:, :nz] = self.aps.Cl_phi_delta[:]
+        cla[:, nz:, :nz] = self.aps.Cl_phi_delta[:].transpose(0, 2, 1)
         cla[:, :nz, :nz] = self.aps.Cl_phi_phi[:]
 
         # Generate map
@@ -455,12 +473,14 @@ class GenerateInitialLSSFromCl(tasklib.base.ContainerTask):
                 cosmology=self.cosmology,
                 nside=self.nside,
                 freq=self.aps.freq,
+                d2phi=self.aps.d2phi,
             )
         else:
             f = InitialLSS(
                 cosmology=self.cosmology,
                 nside=self.nside,
                 redshift=self.aps.redshift,
+                d2phi=self.aps.d2phi,
             )
 
         # Redistribute over the pixel axis to properly
@@ -793,6 +813,12 @@ class ZeldovichDynamics(DynamicsBase):
         initial_field.redistribute("chi")
         biased_field.redistribute("chi")
 
+        if initial_field.d2phi:
+            raise NotImplementedError(
+                "Cannot compute Zel'dovich dynamics from InitialLSS object that "
+                "stores phi radial derivative."
+            )
+
         lsel = initial_field.phi[:].local_bounds
 
         self._validate_fields(initial_field, biased_field)
@@ -917,7 +943,10 @@ class LinearDynamics(DynamicsBase):
 
         if self.redshift_space:
             fr = c.growth_rate(za)
-            vterm = lssutil.diff2(iphi, chi[:], axis=0)
+            if initial_field.d2phi:
+                vterm = iphi.copy()
+            else:
+                vterm = lssutil.diff2(iphi, chi[:], axis=0)
             vterm *= -(D * fr)[:, np.newaxis]
 
             if self.output_kaiser_only:

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 from functools import cache
 
 import healpy
@@ -26,6 +26,7 @@ from .lsscontainers import (
     BiasedLSS,
     CorrelationFunction,
     MultiFrequencyAngularPowerSpectrum,
+    MultiTracerMultiFrequencyAngularPowerSpectrum,
     InitialLSS,
     MatterPowerSpectrum,
     _INTERP_TYPES,
@@ -312,8 +313,8 @@ class CalculatePFBChannelProfile(tasklib.base.ContainerTask):
         return profile_cont
 
 
-class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
-    """Calculate C_l(chi,chi') from a real-space correlation function.
+class CalculateMultiFrequencyAngularPowerSpectrumBase(tasklib.base.ContainerTask):
+    """Base class for calculating C_l(chi,chi') (non-functional).
 
     The output will be evaluated at constant redshift, corresponding
     to the redshift of the input correlation functions.
@@ -322,13 +323,8 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     where delta is the matter overdensity and phi is the gravitational
     potential (including numerical prefactors from the Poisson equation).
     If `use_d2phi` is set, the second line-of-sight derivative of phi
-    will be used instead of phi. (This is useful to simulating maps of
+    will be used instead of phi. (This is useful for simulating maps of
     the Kaiser redshift-space distortion term.)
-
-    If `FoG_convolve` is set, the integrand of the C_l expression will
-    be convolved with the position-space Finger-of-God damping kernel.
-    Sky maps generated with the output C_l will then include this
-    damping.
 
     Attributes
     ----------
@@ -381,26 +377,6 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     d2phi_freq_padding : int, optional
         Fixed number of padding frequencies. Overridden if `FoG_convolve` is True.
         Default: 1.
-    FoG_convolve : bool, optional
-        Whether to convolve the integrand with the Finger-of-God damping kernel
-        prior to integration. Must choose `channel_method = "uniform"`.
-        Default: False.
-    alpha_FoG : float
-        A parameter to control the strength of the effect by adjusting the damping
-        scale. A value of 1 (default) applies the nominal damping, 0 turns the
-        damping off entirely, and any other values adjust the scale appropriately.
-    FoG_model : str, optional
-        Use an inbuilt model for the Finger-of-God damping. If None (default), a
-        specific model is expected to be set via `FoG_coeff` and `z_eff`. See
-        `lssmodels.sigma_P` for available models and details about them.
-    FoG_coeff : list, optional
-        A list of coefficients in a polynomial of `FoG_coeff[i] * (z - z_eff)**i`.
-        If None (default), `FoG_model` must be set.
-    FoG_z_eff : float, optional
-        The effective redshift of the polynomial expansion. Default: None.
-    FoG_z_eval : float, optional
-        Redshift at which to evaluate FoG damping model. If not set, mean redshift
-        of input container is used. Default: None.
     FoG_freq_padding_threshold : float, optional
         Requested frequency range is padded such that this fraction of the
         integral of the FoG kernel is captured. Default: 0.99.
@@ -429,12 +405,6 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     freq_padding = config.Property(proptype=bool, default=False)
     d2phi_freq_padding = config.Property(proptype=int, default=1)
 
-    FoG_convolve = config.Property(proptype=bool, default=False)
-    alpha_FoG = config.Property(proptype=float, default=1.0)
-    FoG_model = config.enum(lssmodels.sigma_P.models(), default=None)
-    FoG_coeff = config.list_type(type_=float, default=None)
-    FoG_z_eff = config.Property(proptype=float, default=None)
-    FoG_z_eval = config.Property(proptype=float, default=None)
     FoG_freq_padding_threshold = config.Property(proptype=float, default=0.99)
     FoG_freq_padding_maxnum = config.Property(proptype=int, default=None)
 
@@ -454,9 +424,10 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
         if profile_cont is not None:
             self.channel_profile_func = profile_cont.get_function("profile")
 
-    def process(
-        self, correlation_functions: CorrelationFunction
-    ) -> MultiFrequencyAngularPowerSpectrum:
+    def process(self, correlation_functions: CorrelationFunction) -> Union[
+        MultiFrequencyAngularPowerSpectrum,
+        MultiTracerMultiFrequencyAngularPowerSpectrum,
+    ]:
         """Compute the angular power spectra.
 
         Returns
@@ -500,60 +471,37 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
         # power will alias back down when the map is transformed later on
         lmax = 3 * self.nside - 1
 
-        # If alpha_FoG is 0, don't do FoG convolution even if requested
-        # by user
-        if self.alpha_FoG == 0:
-            self.FoG_convolve = False
+        # Compute FoG damping scale(s). "None" corresponds to no damping.
+        sigma_P_arr = self._compute_FoG_damping_scales(redshift)
 
-        # Set FoG damping scale and padding frequencies, if needed
-        if not self.FoG_convolve:
-
-            sigma_P = None
-
+        # Pad frequencies
+        if all(x is None for x in sigma_P_arr):
+            # If all sigma_P values are None, there's no FoG damping,
+            # pad by nfreq_pad frequencies if nonzero
             if nfreq_pad > 0:
                 freqs_new, nfreq_pad, _, _ = lssutil.pad_frequencies(
                     self.frequencies, num=nfreq_pad
                 )
-
         else:
-
-            # Set redshift at which to evaluate model for damping scale
-            if self.FoG_z_eval is not None:
-                z_eval = self.FoG_z_eval
-            else:
-                z_eval = np.mean(redshift)
-
-            # Compute damping scale
-            if self.FoG_z_eff is not None and self.FoG_coeff is not None:
-
-                def s(z):
-                    return lssmodels.PolyModelSet.evaluate_poly(
-                        z, self.FoG_z_eff, self.FoG_coeff
-                    )
-
-                sigma_P = self.alpha_FoG * s(z_eval)
-
-            elif self.FoG_model is not None:
-                sigma_P = self.alpha_FoG * lssmodels.sigma_P[self.FoG_model](z_eval)
-            else:
-                raise config.CaputConfigError(
-                    "Either `FoG_model` must be set, or `FoG_z_eff` and `FoG_coeff`"
-                )
+            # If there's at least one nontrivial sigma_P, find the maximum
+            # value, and pad frequencies based on this value
+            nonzero_sigma_P_arr = np.array([x for x in sigma_P_arr if x is not None])
+            sigma_P_max = np.max(nonzero_sigma_P_arr)
 
             if self.freq_padding:
-                # Pad frequencies to ensure adequate coverage of FoG kernel
+                # Pad frequencies to ensure adequate coverage of widest FoG kernel
                 freqs_new, nfreq_pad, nfreq_pad_raw, FoG_kernel_frac = (
                     lssutil.pad_frequencies(
                         self.frequencies,
                         use_FoG_kernel=True,
                         cosmology=cosmology,
-                        sigma_P=sigma_P,
+                        sigma_P=sigma_P_max,
                         FoG_threshold=self.FoG_freq_padding_threshold,
                         maxnum=self.FoG_freq_padding_maxnum,
                     )
                 )
                 self.log.info(
-                    "Fraction of FoG kernel covered by "
+                    "Fraction of widest FoG kernel with covered by "
                     f"padded frequencies: {FoG_kernel_frac}"
                 )
                 if nfreq_pad != nfreq_pad_raw:
@@ -572,7 +520,118 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
 
             self.log.info(f"Number of padding frequencies: {nfreq_pad}")
 
+        # Compute angular power spectra and assemble into output container
+        out_cont = self._compute_spectra(
+            cosmology,
+            redshift,
+            corr0,
+            corr2,
+            corr4,
+            lmax,
+            xa,
+            nfreq_pad,
+            nfreq_pad_for_kernel,
+            sigma_P_arr,
+        )
+
+        return out_cont
+
+
+class CalculateSingleTracerMultiFrequencyAngularPowerSpectrum(
+    CalculateMultiFrequencyAngularPowerSpectrumBase
+):
+    """Calculate C_l(chi,chi') for a single tracer.
+
+    If `FoG_convolve` is set, the integrand of the C_l expression will
+    be convolved with the position-space Finger-of-God damping kernel.
+    Sky maps generated with the output C_l will then include this
+    damping.
+
+    See docstring for `CalculateMultiFrequencyAngularPowerSpectrumBase`
+    for other attributes not listed below.
+
+    Attributes
+    ----------
+    FoG_convolve : bool, optional
+        Whether to convolve the integrand with the Finger-of-God damping kernel
+        prior to integration. Must choose `channel_method = "uniform"`.
+        Default: False.
+    alpha_FoG : float
+        A parameter to control the strength of the effect by adjusting the damping
+        scale. A value of 1 (default) applies the nominal damping, 0 turns the
+        damping off entirely, and any other values adjust the scale appropriately.
+    FoG_model : str, optional
+        Use an inbuilt model for the Finger-of-God damping. If None (default), a
+        specific model is expected to be set via `FoG_coeff` and `z_eff`. See
+        `lssmodels.sigma_P` for available models and details about them.
+    FoG_coeff : list, optional
+        A list of coefficients in a polynomial of `FoG_coeff[i] * (z - z_eff)**i`.
+        If None (default), `FoG_model` must be set.
+    FoG_z_eff : float, optional
+        The effective redshift of the polynomial expansion. Default: None.
+    FoG_z_eval : float, optional
+        Redshift at which to evaluate FoG damping model. If not set, mean redshift
+        of input container is used. Default: None.
+    """
+
+    FoG_convolve = config.Property(proptype=bool, default=False)
+    alpha_FoG = config.Property(proptype=float, default=1.0)
+    FoG_model = config.enum(lssmodels.sigma_P.models(), default=None)
+    FoG_coeff = config.list_type(type_=float, default=None)
+    FoG_z_eff = config.Property(proptype=float, default=None)
+    FoG_z_eval = config.Property(proptype=float, default=None)
+
+    def _compute_FoG_damping_scales(self, redshift: np.ndarray) -> np.ndarray:
+        """Compute FoG damping scale for desired tracer."""
+
+        # If alpha_FoG is 0, return "None" for damping scale,
+        # indicating that damping should not be applied
+        if self.alpha_FoG == 0 or not self.FoG_convolve:
+            return np.array([None])
+
+        # Set redshift at which to evaluate model for damping scale
+        if self.FoG_z_eval is not None:
+            z_eval = self.FoG_z_eval
+        else:
+            z_eval = np.mean(redshift)
+
+        # Compute damping scale
+        if self.FoG_z_eff is not None and self.FoG_coeff is not None:
+
+            def s(z):
+                return lssmodels.PolyModelSet.evaluate_poly(
+                    z, self.FoG_z_eff, self.FoG_coeff
+                )
+
+            sigma_P = self.alpha_FoG * s(z_eval)
+
+        elif self.FoG_model is not None:
+            sigma_P = self.alpha_FoG * lssmodels.sigma_P[self.FoG_model](z_eval)
+        else:
+            raise config.CaputConfigError(
+                "Either `FoG_model`, or `FoG_z_eff` and `FoG_coeff`, must be set"
+            )
+
+        return np.array([sigma_P])
+
+    def _compute_spectra(
+        self,
+        cosmology,
+        redshift,
+        corr0,
+        corr2,
+        corr4,
+        lmax,
+        xa,
+        nfreq_pad,
+        nfreq_pad_for_kernel,
+        sigma_P_arr,
+    ):
+        """Compute angular power spectra for desired tracer."""
+
         phi_label = "d2phi" if self.use_d2phi else "phi"
+
+        sigma_P = sigma_P_arr[0]
 
         self.log.debug("Generating C_l(x, x') for delta-delta")
         cla0 = corrfunc.corr_to_clarray(
@@ -652,6 +711,335 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
         out_cont.Cl_delta_delta[:] = cla0[:, slc, slc]
         out_cont.Cl_phi_delta[:] = cla2[:, slc, slc]
         out_cont.Cl_phi_phi[:] = cla4[:, slc, slc]
+
+        return out_cont
+
+
+# Alias for legacy compatibility
+CalculateMultiFrequencyAngularPowerSpectrum = (
+    CalculateSingleTracerMultiFrequencyAngularPowerSpectrum
+)
+
+
+class CalculateDoubleTracerMultiFrequencyAngularPowerSpectrum(
+    CalculateMultiFrequencyAngularPowerSpectrumBase
+):
+    """Calculate C_l(chi,chi') for two correlated tracers.
+
+    If `FoG_convolve` is set, the integrand of the C_l expression will
+    be convolved with the position-space Finger-of-God damping kernel.
+    Sky maps generated with the output C_l will then include this
+    damping.
+
+    See docstring for `CalculateMultiFrequencyAngularPowerSpectrumBase`
+    for other attributes not listed below.
+
+    Attributes
+    ----------
+    FoG_convolve : bool, optional
+        Whether to convolve the integrand with the Finger-of-God damping kernel
+        prior to integration. Must choose `channel_method = "uniform"`.
+        Default: False.
+    alpha_FoG_A, alpha_FoG_B : float
+        A parameter to control the strength of the effect by adjusting the damping
+        scale for each tracer. A value of 1 (default) applies the nominal damping,
+        0 turns the damping off entirely, and any other values adjust the scale
+        appropriately.
+    FoG_model_A, FoG_model_B : str, optional
+        Use an inbuilt model for the Finger-of-God damping. If None (default), a
+        specific model is expected to be set via `FoG_coeff` and `z_eff`. See
+        `lssmodels.sigma_P` for available models and details about them.
+    FoG_coeff_A, FoG_coeff_B : list, optional
+        A list of coefficients in a polynomial of `FoG_coeff[i] * (z - z_eff)**i`.
+        If None (default), `FoG_model` must be set.
+    FoG_z_eff_A, FoG_z_eff_B : float, optional
+        The effective redshift of the polynomial expansion. Default: None.
+    FoG_z_eval_A, FoG_z_eval_B : float, optional
+        Redshift at which to evaluate FoG damping model. If not set, mean redshift
+        of input container is used. Default: None.
+    """
+
+    FoG_convolve = config.Property(proptype=bool, default=False)
+
+    alpha_FoG_A = config.Property(proptype=float, default=1.0)
+    FoG_model_A = config.enum(lssmodels.sigma_P.models(), default=None)
+    FoG_coeff_A = config.list_type(type_=float, default=None)
+    FoG_z_eff_A = config.Property(proptype=float, default=None)
+    FoG_z_eval_A = config.Property(proptype=float, default=None)
+
+    alpha_FoG_B = config.Property(proptype=float, default=1.0)
+    FoG_model_B = config.enum(lssmodels.sigma_P.models(), default=None)
+    FoG_coeff_B = config.list_type(type_=float, default=None)
+    FoG_z_eff_B = config.Property(proptype=float, default=None)
+    FoG_z_eval_B = config.Property(proptype=float, default=None)
+
+    def _compute_FoG_damping_scales(self, redshift: np.ndarray) -> np.ndarray:
+        """Compute FoG damping scales for both tracers."""
+
+        sigma_P_arr = [None, None]
+
+        for i, (alpha_FoG, FoG_model, FoG_coeff, FoG_z_eff, FoG_z_eval) in enumerate(
+            zip(
+                [self.alpha_FoG_A, self.alpha_FoG_B],
+                [self.FoG_model_A, self.FoG_model_B],
+                [self.FoG_coeff_A, self.FoG_coeff_B],
+                [self.FoG_z_eff_A, self.FoG_z_eff_B],
+                [self.FoG_z_eval_A, self.FoG_z_eval_B],
+            )
+        ):
+            # If alpha_FoG is 0, leave damping scale as "None",
+            # indicating that damping should not be applied
+            if alpha_FoG == 0 or not self.FoG_convolve:
+                continue
+
+            # Set redshift at which to evaluate model for damping scale
+            if FoG_z_eval is not None:
+                z_eval = FoG_z_eval
+            else:
+                z_eval = np.mean(redshift)
+
+            # Compute damping scale
+            if FoG_z_eff is not None and FoG_coeff is not None:
+
+                def s(z):
+                    return lssmodels.PolyModelSet.evaluate_poly(z, FoG_z_eff, FoG_coeff)
+
+                sigma_P_arr[i] = alpha_FoG * s(z_eval)
+
+            elif FoG_model is not None:
+                sigma_P_arr[i] = alpha_FoG * lssmodels.sigma_P[FoG_model](z_eval)
+            else:
+                raise config.CaputConfigError(
+                    "Either `FoG_model`, or `FoG_z_eff` and `FoG_coeff`, must be set"
+                )
+
+        return np.array(sigma_P_arr)
+
+    def _compute_spectra(
+        self,
+        cosmology,
+        redshift,
+        corr0,
+        corr2,
+        corr4,
+        lmax,
+        xa,
+        nfreq_pad,
+        nfreq_pad_for_kernel,
+        sigma_P_arr,
+    ):
+        """Compute multi-tracer angular power spectra."""
+
+        _SMALL_NONZERO_DAMPING = 1e-5
+
+        phi_label = "d2phi" if self.use_d2phi else "phi"
+
+        # If extra frequencies were added, slice back to original
+        # set of frequencies
+        if nfreq_pad > 0:
+            slc = slice(nfreq_pad, -nfreq_pad)
+        else:
+            slc = slice(None)
+
+        # Create output container
+        if self.frequencies is not None:
+            out_cont = MultiTracerMultiFrequencyAngularPowerSpectrum(
+                cosmology=cosmology,
+                freq=self.frequencies,
+                lmax=lmax,
+                n_tracer=2,
+                d2phi=self.use_d2phi,
+                nfreq_pad=nfreq_pad,
+            )
+        else:
+            out_cont = MultiTracerMultiFrequencyAngularPowerSpectrum(
+                cosmology=cosmology,
+                redshift=redshift,
+                lmax=lmax,
+                n_tracer=2,
+                d2phi=self.use_d2phi,
+                nfreq_pad=nfreq_pad,
+            )
+
+        sigma_A, sigma_B = sigma_P_arr
+
+        # Convert "None" to 0.0 for purposes of numerical comparison
+        def _norm_sigma(x):
+            return 0.0 if x is None else x
+
+        sigma_A_num = _norm_sigma(sigma_A)
+        sigma_B_num = _norm_sigma(sigma_B)
+
+        # If one sigma is zero and the other is not, bump zero to small nonzero
+        # value
+        if (
+            np.isclose(sigma_A_num, 0.0) or np.isclose(sigma_B_num, 0.0)
+        ) and not np.isclose(sigma_A_num, sigma_B_num):
+            sigma_A = _SMALL_NONZERO_DAMPING if sigma_A is None else sigma_A
+            sigma_B = _SMALL_NONZERO_DAMPING if sigma_B is None else sigma_A
+
+        # Check whether the two damping scales are identical
+        identical_damping = np.isclose(sigma_A_num, sigma_B_num)
+
+        self.log.debug("Generating C_l(x, x') for deltaA-deltaA")
+        cla = corrfunc.corr_to_clarray(
+            corr0,
+            lmax,
+            xa,
+            xromb=self.xromb,
+            q=self.leg_q,
+            chunksize=self.leg_chunksize,
+            channel_method=self.channel_method,
+            FoG_convolve=self.FoG_convolve,
+            FoG_sigmaP=sigma_A,
+            FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+            channel_profile=self.channel_profile_func,
+            overlapping_channels=self.overlapping_channels,
+        )
+        # Cl_delta_delta[0] -> A-A
+        out_cont.Cl_delta_delta[0, :] = cla[:, slc, slc]
+
+        self.log.debug(f"Generating C_l(x, x') for {phi_label}A-deltaA")
+        cla = corrfunc.corr_to_clarray(
+            corr2,
+            lmax,
+            xa,
+            xromb=self.xromb,
+            q=self.leg_q,
+            chunksize=self.leg_chunksize,
+            channel_method=self.channel_method,
+            FoG_convolve=self.FoG_convolve,
+            FoG_sigmaP=sigma_A,
+            FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+            channel_profile=self.channel_profile_func,
+            overlapping_channels=self.overlapping_channels,
+            chi1_2nd_derivative=self.use_d2phi,
+        )
+        # Cl_phi_delta[0] -> A-A
+        out_cont.Cl_phi_delta[0, :] = cla[:, slc, slc]
+
+        self.log.debug(f"Generating C_l(x, x') for {phi_label}A-{phi_label}A")
+        cla = corrfunc.corr_to_clarray(
+            corr4,
+            lmax,
+            xa,
+            xromb=self.xromb,
+            q=self.leg_q,
+            chunksize=self.leg_chunksize,
+            channel_method=self.channel_method,
+            FoG_convolve=self.FoG_convolve,
+            FoG_sigmaP=sigma_A,
+            FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+            channel_profile=self.channel_profile_func,
+            overlapping_channels=self.overlapping_channels,
+            chi1_2nd_derivative=self.use_d2phi,
+            chi2_2nd_derivative=self.use_d2phi,
+        )
+        # Cl_phi_phi[0] -> A-A
+        out_cont.Cl_phi_phi[0, :] = cla[:, slc, slc]
+
+        # If the FoG scales are identical for each tracer, then we can re-use the
+        # A auto spectra. Otherwise, we need to compute A-B and B-B spectra.
+        if identical_damping:
+
+            self.log.debug(
+                "Identical FoG damping scales detected "
+                "- re-using A-A spectra for A-B and B-B"
+            )
+            for i in range(1, 3):
+                out_cont.Cl_delta_delta[i, :] = out_cont.Cl_delta_delta[0, :]
+                out_cont.Cl_phi_phi[i, :] = out_cont.Cl_phi_phi[0, :]
+
+            for i in range(1, 4):
+                out_cont.Cl_phi_delta[i, :] = out_cont.Cl_phi_delta[0, :]
+
+        else:
+
+            # Cl_delta_delta[1] -> A-B
+            # Cl_delta_delta[2] -> B-B
+            for i, label, sigma_1, sigma_2 in zip(
+                [1, 2],
+                ["deltaA-deltaB", "deltaB-deltaB"],
+                [sigma_A, sigma_B],
+                [sigma_B, None],
+            ):
+                self.log.debug(f"Generating C_l(x, x') for {label}")
+                cla = corrfunc.corr_to_clarray(
+                    corr0,
+                    lmax,
+                    xa,
+                    xromb=self.xromb,
+                    q=self.leg_q,
+                    chunksize=self.leg_chunksize,
+                    channel_method=self.channel_method,
+                    FoG_convolve=self.FoG_convolve,
+                    FoG_sigmaP=sigma_1,
+                    FoG_sigmaP_other=sigma_2,
+                    FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+                    channel_profile=self.channel_profile_func,
+                    overlapping_channels=self.overlapping_channels,
+                )
+                out_cont.Cl_delta_delta[i, :] = cla[:, slc, slc]
+
+            # Cl_phi_delta[1] -> A-B
+            # Cl_phi_delta[2] -> B-A
+            # Cl_phi_delta[3] -> B-B
+            for i, label, sigma_1, sigma_2 in zip(
+                [1, 2, 3],
+                [
+                    f"{phi_label}A-deltaB",
+                    f"{phi_label}B-deltaA",
+                    f"{phi_label}B-deltaB",
+                ],
+                [sigma_A, sigma_B, sigma_B],
+                [sigma_B, sigma_A, sigma_B],
+            ):
+                self.log.debug(f"Generating C_l(x, x') for {label}")
+                cla = corrfunc.corr_to_clarray(
+                    corr2,
+                    lmax,
+                    xa,
+                    xromb=self.xromb,
+                    q=self.leg_q,
+                    chunksize=self.leg_chunksize,
+                    channel_method=self.channel_method,
+                    FoG_convolve=self.FoG_convolve,
+                    FoG_sigmaP=sigma_1,
+                    FoG_sigmaP_other=sigma_2,
+                    FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+                    channel_profile=self.channel_profile_func,
+                    overlapping_channels=self.overlapping_channels,
+                    chi1_2nd_derivative=self.use_d2phi,
+                )
+                out_cont.Cl_phi_delta[i, :] = cla[:, slc, slc]
+
+            # Cl_phi_phi[1] -> A-B
+            # Cl_phi_phi[2] -> B-B
+            for i, label, sigma_1, sigma_2 in zip(
+                [1, 2],
+                [f"{phi_label}A-{phi_label}B", f"{phi_label}B-{phi_label}B"],
+                [sigma_A, sigma_B],
+                [sigma_B, None],
+            ):
+                self.log.debug(f"Generating C_l(x, x') for {label}")
+                cla = corrfunc.corr_to_clarray(
+                    corr4,
+                    lmax,
+                    xa,
+                    xromb=self.xromb,
+                    q=self.leg_q,
+                    chunksize=self.leg_chunksize,
+                    channel_method=self.channel_method,
+                    FoG_convolve=self.FoG_convolve,
+                    FoG_sigmaP=sigma_1,
+                    FoG_sigmaP_other=sigma_2,
+                    FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
+                    channel_profile=self.channel_profile_func,
+                    overlapping_channels=self.overlapping_channels,
+                    chi1_2nd_derivative=self.use_d2phi,
+                    chi2_2nd_derivative=self.use_d2phi,
+                )
+                out_cont.Cl_phi_phi[i, :] = cla[:, slc, slc]
 
         return out_cont
 

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -475,9 +475,12 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
                     )
 
         # If necessary, generate new comoving-distance array from padded frequencies
+        nfreq_pad_for_kernel = None
         if nfreq_pad > 0:
             redshift_new = units.nu21 / freqs_new - 1.0
             xa = cosmology.comoving_distance(redshift_new)
+
+            nfreq_pad_for_kernel = nfreq_pad
 
             self.log.info(f"Number of padding frequencies: {nfreq_pad}")
 
@@ -494,6 +497,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             channel_method=self.channel_method,
             FoG_convolve=self.FoG_convolve,
             FoG_sigmaP=sigma_P,
+            FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
         )
 
         self.log.debug(f"Generating C_l(x, x') for {phi_label}-delta")
@@ -507,6 +511,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             channel_method=self.channel_method,
             FoG_convolve=self.FoG_convolve,
             FoG_sigmaP=sigma_P,
+            FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
             chi1_2nd_derivative=self.use_d2phi,
         )
 
@@ -521,6 +526,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             channel_method=self.channel_method,
             FoG_convolve=self.FoG_convolve,
             FoG_sigmaP=sigma_P,
+            FoG_kernel_max_nchannels=nfreq_pad_for_kernel,
             chi1_2nd_derivative=self.use_d2phi,
             chi2_2nd_derivative=self.use_d2phi,
         )

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -453,7 +453,7 @@ class CalculateMultiFrequencyAngularPowerSpectrumBase(tasklib.base.ContainerTask
 
         if self.frequencies is None:
             redshift = self.redshift
-            self.frequencies = units.nu_21 / (1.0 + redshift)
+            self.frequencies = constants.nu21 / (1.0 + redshift)
         else:
             redshift = constants.nu21 / self.frequencies - 1.0
 
@@ -513,7 +513,7 @@ class CalculateMultiFrequencyAngularPowerSpectrumBase(tasklib.base.ContainerTask
         # If necessary, generate new comoving-distance array from padded frequencies
         nfreq_pad_for_kernel = None
         if nfreq_pad > 0:
-            redshift_new = units.nu21 / freqs_new - 1.0
+            redshift_new = constants.nu21 / freqs_new - 1.0
             xa = cosmology.comoving_distance(redshift_new)
 
             nfreq_pad_for_kernel = nfreq_pad

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -320,6 +320,19 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     FoG_z_eval : float, optional
         Redshift at which to evaluate FoG damping model. If not set, mean redshift
         of input container is used. Default: None.
+    FoG_freq_padding : bool, optional
+        Add extra high and low frequencies so that FoG convolution is accurately
+        performed at highest and lowest frequencies specified in `frequencies` or
+        `redshift`. The number of extra frequencies is computed such that the FoG
+        convolution for the requested edge frequencies captures contributions
+        from some fraction of the integral of the FoG kernel, specified by
+        `FoG_freq_padding_threshold`. Default: False.
+    FoG_freq_padding_threshold : float, optional
+        Requested frequency range is padded such that this fraction of the
+        integral of the FoG kernel is captured. Default: 0.99.
+    FoG_freq_padding_maxnum : int, optional
+        Maximum number of frequencies to pad by (to limit the maximum computational
+        cost). Default: None.
     """
 
     nside = config.Property(proptype=int)
@@ -342,6 +355,9 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     FoG_coeff = config.list_type(type_=float, default=None)
     FoG_z_eff = config.Property(proptype=float, default=None)
     FoG_z_eval = config.Property(proptype=float, default=None)
+    FoG_freq_padding = config.Property(proptype=bool, default=False)
+    FoG_freq_padding_threshold = config.Property(proptype=float, default=0.99)
+    FoG_freq_padding_maxnum = config.Property(proptype=int, default=None)
 
     def process(
         self, correlation_functions: CorrelationFunction
@@ -371,10 +387,13 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
 
         if self.frequencies is None:
             redshift = self.redshift
+            self.frequencies = units.nu_21 / (1.0 + redshift)
         else:
             redshift = constants.nu21 / self.frequencies - 1.0
 
         xa = cosmology.comoving_distance(redshift)
+
+        nfreq_pad = 0
 
         # NOTE: it is important not to set this any higher. Otherwise,
         # power will alias back down when the map is transformed later on
@@ -385,14 +404,15 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
         if self.alpha_FoG == 0:
             self.FoG_convolve = False
 
-        # If using FoG, initialize fiducial model for damping scale.
         if self.FoG_convolve:
 
+            # Set redshift at which to evaluate model for damping scale
             if self.FoG_z_eval is not None:
                 z_eval = self.FoG_z_eval
             else:
                 z_eval = np.mean(redshift)
 
+            # Compute damping scale
             if self.FoG_z_eff is not None and self.FoG_coeff is not None:
 
                 def s(z):
@@ -403,10 +423,57 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
                 sigma_P = self.alpha_FoG * s(z_eval)
 
             elif self.FoG_model is not None:
-                sigma_P = lssmodels.sigma_P[self.FoG_model](z_eval)
+                sigma_P = self.alpha_FoG * lssmodels.sigma_P[self.FoG_model](z_eval)
             else:
                 raise config.CaputConfigError(
                     "Either `FoG_model` must be set, or `FoG_z_eff` and `FoG_coeff`"
+                )
+
+            if self.FoG_freq_padding:
+                # Generate list of frequencies that's extended at the low end
+                nfreq = len(self.frequencies)
+                freqs_sorted = np.sort(self.frequencies)
+                dfreq = np.median(np.diff(freqs_sorted))
+                freqs_extended = np.concatenate(
+                    [freqs_sorted - dfreq * nfreq, freqs_sorted]
+                )
+
+                # Compute corresponding extended list of comoving-distance
+                # differences from lowest frequency in original list
+                dx_extended = cosmology.comoving_distance(freqs_extended)
+                dx_extended -= dx_extended[nfreq]
+
+                # Evaluate normalized FoG kernel at values in this list
+                # and evaluate cumulative sum
+                kernel_extended = lssutil.exponential_FoG_kernel_1d(
+                    dx_extended, sigma_P, normalize=True
+                )
+                kernel_cumsum = np.cumsum(kernel_extended)
+
+                # Find number of extra frequencies required to cover
+                # requested fraction of kernel integral
+                nfreq_pad = max(
+                    np.sum(kernel_cumsum > 1 - self.FoG_freq_padding_threshold) - nfreq,
+                    0,
+                )
+                if self.FoG_freq_padding_maxnum is not None:
+                    nfreq_pad = min(nfreq_pad, self.FoG_freq_padding_maxnum)
+
+                # Make new arrays of frequencies, redshifts, and comoving distances
+                freqs_new = np.concatenate(
+                    [
+                        freqs_sorted[0] - np.arange(1, nfreq_pad + 1)[::-1] * dfreq,
+                        freqs_sorted,
+                        freqs_sorted[-1] + np.arange(1, nfreq_pad + 1) * dfreq,
+                    ]
+                )
+                if not np.array_equal(freqs_sorted, self.frequencies):
+                    freqs_new = freqs_new[::-1]
+                redshift_new = units.nu21 / freqs_new - 1.0
+                xa = cosmology.comoving_distance(redshift_new)
+
+                self.log.info(
+                    f"Padded frequency range with {nfreq_pad} elements at each end"
                 )
 
         else:
@@ -462,6 +529,7 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
                 freq=self.frequencies,
                 lmax=lmax,
                 d2phi=self.use_d2phi,
+                nfreq_pad=nfreq_pad,
             )
         else:
             out_cont = MultiFrequencyAngularPowerSpectrum(
@@ -469,11 +537,19 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
                 redshift=redshift,
                 lmax=lmax,
                 d2phi=self.use_d2phi,
+                nfreq_pad=nfreq_pad,
             )
 
-        out_cont.Cl_delta_delta[:] = cla0
-        out_cont.Cl_phi_delta[:] = cla2
-        out_cont.Cl_phi_phi[:] = cla4
+        # If extra frequencies were added, slice back to original
+        # set of frequencies
+        if nfreq_pad > 0:
+            slc = slice(nfreq_pad, -nfreq_pad)
+        else:
+            slc = slice(None)
+
+        out_cont.Cl_delta_delta[:] = cla0[:, slc, slc]
+        out_cont.Cl_phi_delta[:] = cla2[:, slc, slc]
+        out_cont.Cl_phi_phi[:] = cla4[:, slc, slc]
 
         return out_cont
 

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -1171,7 +1171,7 @@ class GenerateDoubleTracerInitialLSSFromCl(GenerateSingleTracerInitialLSSFromCl)
         """
         # Stop if we've already generated enough realizations
         if self.num_sims == 0:
-            raise pipeline.PipelineStopIteration()
+            raise exceptions.PipelineStopIteration()
         self.num_sims -= 1
 
         nz = len(self.aps.chi)

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -1044,7 +1044,7 @@ class CalculateDoubleTracerMultiFrequencyAngularPowerSpectrum(
         return out_cont
 
 
-class GenerateInitialLSSFromCl(tasklib.base.ContainerTask):
+class GenerateSingleTracerInitialLSSFromCl(tasklib.base.ContainerTask):
     """Generate initial LSS maps from input angular power spectrum.
 
     Attributes
@@ -1151,9 +1151,120 @@ class GenerateInitialLSSFromCl(tasklib.base.ContainerTask):
         return f
 
 
+# Alias for legacy compatibility
+GenerateInitialLSSFromCl = GenerateSingleTracerInitialLSSFromCl
+
+
+class GenerateDoubleTracerInitialLSSFromCl(GenerateSingleTracerInitialLSSFromCl):
+    """Generate initial LSS maps for two correlated tracers.
+
+    See `GenerateSingleTracerInitialLSSFromCl` docstring for attribute descriptions.
+    """
+
+    def process(self) -> Tuple[InitialLSS, InitialLSS]:
+        """Generate correlated realisations of the LSS initial conditions.
+
+        Returns
+        -------
+        fA, fB
+            The LSS initial conditions for each tracer.
+        """
+        # Stop if we've already generated enough realizations
+        if self.num_sims == 0:
+            raise pipeline.PipelineStopIteration()
+        self.num_sims -= 1
+
+        nz = len(self.aps.chi)
+
+        # Create extended covariance matrix capturing cross-correlations
+        # between the phi and delta fields for the two tracers:
+        #  pA-pA dA-pA pB-pA dB-pA
+        #  pA-dA dA-dA pB-dA dB-dA
+        #  pA-pB dA-pB pB-pB dB-pB
+        #  pA-dB dA-dB pB-dB dB-dB
+        cla = mpiarray.zeros((len(self.aps.ell), 4 * nz, 4 * nz), axis=0)
+
+        cla[:, :nz, :nz] = self.aps.Cl_phi_phi[0, :]
+        cla[:, nz : 2 * nz, :nz] = self.aps.Cl_phi_delta[0, :]
+        cla[:, 2 * nz : 3 * nz, :nz] = self.aps.Cl_phi_phi[1, :]
+        cla[:, 3 * nz : 4 * nz, :nz] = self.aps.Cl_phi_delta[1, :]
+
+        cla[:, :nz, nz : 2 * nz] = self.aps.Cl_phi_delta[0, :].transpose(0, 2, 1)
+        cla[:, nz : 2 * nz, nz : 2 * nz] = self.aps.Cl_delta_delta[0, :]
+        cla[:, 2 * nz : 3 * nz, nz : 2 * nz] = self.aps.Cl_phi_delta[2, :].transpose(
+            0, 2, 1
+        )
+        cla[:, 3 * nz : 4 * nz, nz : 2 * nz] = self.aps.Cl_delta_delta[1, :]
+
+        cla[:, :nz, 2 * nz : 3 * nz] = self.aps.Cl_phi_phi[1, :].transpose(0, 2, 1)
+        cla[:, nz : 2 * nz, 2 * nz : 3 * nz] = self.aps.Cl_phi_delta[2, :]
+        cla[:, 2 * nz : 3 * nz, 2 * nz : 3 * nz] = self.aps.Cl_phi_phi[2, :]
+        cla[:, 3 * nz : 4 * nz, 2 * nz : 3 * nz] = self.aps.Cl_phi_delta[3, :]
+
+        cla[:, :nz, 3 * nz : 4 * nz] = self.aps.Cl_phi_delta[1, :].transpose(0, 2, 1)
+        cla[:, nz : 2 * nz, 3 * nz : 4 * nz] = self.aps.Cl_delta_delta[1, :].transpose(
+            0, 2, 1
+        )
+        cla[:, 2 * nz : 3 * nz, 3 * nz : 4 * nz] = self.aps.Cl_phi_delta[
+            3, :
+        ].transpose(0, 2, 1)
+        cla[:, 3 * nz : 4 * nz, 3 * nz : 4 * nz] = self.aps.Cl_delta_delta[2, :]
+
+        # Generate map
+        self.log.info(f"Generating realisation of fields using seed {self.seed}")
+        rng = np.random.default_rng(self.seed)
+        sky = skysim.mkfullsky(cla, self.nside, rng=rng)
+
+        # Make container for output
+        if self.aps.freq is not None:
+            fA = InitialLSS(
+                cosmology=self.cosmology,
+                nside=self.nside,
+                freq=self.aps.freq,
+                d2phi=self.aps.d2phi,
+            )
+            fB = InitialLSS(
+                cosmology=self.cosmology,
+                nside=self.nside,
+                freq=self.aps.freq,
+                d2phi=self.aps.d2phi,
+            )
+        else:
+            fA = InitialLSS(
+                cosmology=self.cosmology,
+                nside=self.nside,
+                redshift=self.aps.redshift,
+                d2phi=self.aps.d2phi,
+            )
+            fB = InitialLSS(
+                cosmology=self.cosmology,
+                nside=self.nside,
+                redshift=self.aps.redshift,
+                d2phi=self.aps.d2phi,
+            )
+
+        # Redistribute over the pixel axis to properly
+        # index the sky nz axis
+        fA.redistribute("pixel")
+        fB.redistribute("pixel")
+        sky = sky.redistribute(axis=1)
+
+        fA.phi[:] = sky[:nz]
+        fA.delta[:] = sky[nz : 2 * nz]
+        fB.phi[:] = sky[2 * nz : 3 * nz]
+        fB.delta[:] = sky[3 * nz : 4 * nz]
+
+        fA.redistribute("chi")
+        fB.redistribute("chi")
+
+        self.seed += 1
+
+        return fA, fB
+
+
 class GenerateInitialLSS(
-    CalculateMultiFrequencyAngularPowerSpectrum,
-    GenerateInitialLSSFromCl,
+    CalculateSingleTracerMultiFrequencyAngularPowerSpectrum,
+    GenerateSingleTracerInitialLSSFromCl,
 ):
     """Generate initial LSS maps from a correlation function.
 
@@ -1162,13 +1273,13 @@ class GenerateInitialLSS(
     """
 
     def setup(self, correlation_functions: CorrelationFunction):
-        aps = CalculateMultiFrequencyAngularPowerSpectrum.process(
+        aps = CalculateSingleTracerMultiFrequencyAngularPowerSpectrum.process(
             self, correlation_functions
         )
-        GenerateInitialLSSFromCl.setup(self, aps)
+        GenerateSingleTracerInitialLSSFromCl.setup(self, aps)
 
     def process(self):
-        return GenerateInitialLSSFromCl.process(self)
+        return GenerateSingleTracerInitialLSSFromCl.process(self)
 
 
 class GenerateBiasedFieldBase(tasklib.base.ContainerTask):

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -8,6 +8,7 @@ import numpy as np
 from caput import config, mpiarray
 from caput.astro import constants
 from caput.pipeline import exceptions, tasklib
+from caput.util import pfb
 
 from ..core import containers, skysim
 from ..util import hputil
@@ -21,6 +22,7 @@ from ..util.pmesh import (
 from ..util.nputil import FloatArrayLike
 from . import corrfunc, lssutil, lssmodels
 from .lsscontainers import (
+    InterpolatedFunction,
     BiasedLSS,
     CorrelationFunction,
     MultiFrequencyAngularPowerSpectrum,
@@ -241,6 +243,73 @@ class BlendNonLinearPowerSpectrum(tasklib.base.ContainerTask):
         self.done = True
 
         return ps_linear
+
+
+class CalculatePFBChannelProfile(tasklib.base.ContainerTask):
+    """Compute frequency channel profile for CASPER PFB.
+
+    The output is an `InterpolatedFunction` container containing
+    the squared magnitude of the profile computed by
+    `caput.util.pfb.PFB.compute_channel_profile`, which corresponds
+    to the frequency channel profile associataed with a measured
+    visibility.
+
+    Attributes
+    ----------
+    ntap : int
+        Number of taps (i.e. blocks) used in one step of the PFB.
+    lblock : int
+        The length of a block that gets transformed. This is twice the number
+        of output frequencies.
+    window : str, optional
+        The window function being used. Must be one of "sinc", "sinc_hann",
+        or "sinc_hamming". Default: "sinc-hamming" (which is used for CHIME).
+    oversample : int, optional
+        The amount to oversample when calculating the decorrelation ratio.
+        This will improve accuracy. The default (16) is typically
+        sufficient for CHIME.
+    """
+
+    ntap = config.Property(proptype=int)
+    lblock = config.Property(proptype=int)
+    window = config.enum(["sinc", "sinc_hann", "sinc_hamming"], default="sinc_hamming")
+    oversample = config.Property(proptype=int, default=16)
+
+    def process(self) -> InterpolatedFunction:
+        """Construct the profile interpolating function.
+
+        Returns
+        -------
+        profile_cont
+            Container with interpolating function for profile.
+        """
+
+        # Mapping from input string to window routine in caput.pfb
+        _window_function = {
+            "sinc": pfb.sinc_window,
+            "sinc_hann": pfb.sinc_hann,
+            "sinc_hamming": pfb.sinc_hamming,
+        }
+
+        # Instantiate PFB object
+        pfb_ = pfb.PFB(
+            self.ntap,
+            self.lblock,
+            _window_function[self.window],
+            oversample=self.oversample,
+        )
+
+        # Compute voltage profile and square to obtain profile for visibility
+        rel_freq, profile_vals = pfb_.compute_channel_profile(norm=True)
+        profile_vals = np.abs(profile_vals) ** 2
+
+        # Create output container
+        profile_cont = InterpolatedFunction()
+        profile_cont.add_function("profile", rel_freq, profile_vals, type="linear")
+
+        self.done = True
+
+        return profile_cont
 
 
 class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -300,6 +300,18 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     use_d2phi : bool, optional
         Compute spectra corresponding to the second line-of-sight
         derivative of phi instead of phi itself. Default: False.
+    freq_padding : bool, optional
+        Add extra high and low frequencies so that Kaiser-term derivatives and
+        FoG convolution are accurately performed at highest and lowest frequencies
+        specified in `frequencies` or `redshift`. If `FoG_convolve` is False,
+        `d2phi_freq_padding` extra frequencies are added at each end.
+        If `FoG_convolve` is True, the number of extra frequencies is computed
+        such that the FoG convolution for the requested edge frequencies captures
+        contributions from some fraction of the integral of the FoG kernel,
+        specified by `FoG_freq_padding_threshold`. Default: False.
+    d2phi_freq_padding : int, optional
+        Fixed number of padding frequencies. Overridden if `FoG_convolve` is True.
+        Default: 1.
     FoG_convolve : bool, optional
         Whether to convolve the integrand with the Finger-of-God damping kernel
         prior to integration. Must choose `channel_method = "uniform"`.
@@ -320,13 +332,6 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     FoG_z_eval : float, optional
         Redshift at which to evaluate FoG damping model. If not set, mean redshift
         of input container is used. Default: None.
-    FoG_freq_padding : bool, optional
-        Add extra high and low frequencies so that FoG convolution is accurately
-        performed at highest and lowest frequencies specified in `frequencies` or
-        `redshift`. The number of extra frequencies is computed such that the FoG
-        convolution for the requested edge frequencies captures contributions
-        from some fraction of the integral of the FoG kernel, specified by
-        `FoG_freq_padding_threshold`. Default: False.
     FoG_freq_padding_threshold : float, optional
         Requested frequency range is padded such that this fraction of the
         integral of the FoG kernel is captured. Default: 0.99.
@@ -349,13 +354,15 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
 
     use_d2phi = config.Property(proptype=bool, default=False)
 
+    freq_padding = config.Property(proptype=bool, default=False)
+    d2phi_freq_padding = config.Property(proptype=int, default=1)
+
     FoG_convolve = config.Property(proptype=bool, default=False)
     alpha_FoG = config.Property(proptype=float, default=1.0)
     FoG_model = config.enum(lssmodels.sigma_P.models(), default=None)
     FoG_coeff = config.list_type(type_=float, default=None)
     FoG_z_eff = config.Property(proptype=float, default=None)
     FoG_z_eval = config.Property(proptype=float, default=None)
-    FoG_freq_padding = config.Property(proptype=bool, default=False)
     FoG_freq_padding_threshold = config.Property(proptype=float, default=0.99)
     FoG_freq_padding_maxnum = config.Property(proptype=int, default=None)
 
@@ -395,6 +402,12 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
 
         nfreq_pad = 0
 
+        # If padding frequencies, set number to default to ensure accurate
+        # Kaiser-term derivatives at lowest and highest frequency. This is
+        # overridden below if FoG convolution is turned on.
+        if self.freq_padding:
+            nfreq_pad = self.d2phi_freq_padding
+
         # NOTE: it is important not to set this any higher. Otherwise,
         # power will alias back down when the map is transformed later on
         lmax = 3 * self.nside - 1
@@ -404,7 +417,17 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
         if self.alpha_FoG == 0:
             self.FoG_convolve = False
 
-        if self.FoG_convolve:
+        # Set FoG damping scale and padding frequencies, if needed
+        if not self.FoG_convolve:
+
+            sigma_P = None
+
+            if nfreq_pad > 0:
+                freqs_new, nfreq_pad, _, _ = lssutil.pad_frequencies(
+                    self.frequencies, num=nfreq_pad
+                )
+
+        else:
 
             # Set redshift at which to evaluate model for damping scale
             if self.FoG_z_eval is not None:
@@ -429,55 +452,34 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
                     "Either `FoG_model` must be set, or `FoG_z_eff` and `FoG_coeff`"
                 )
 
-            if self.FoG_freq_padding:
-                # Generate list of frequencies that's extended at the low end
-                nfreq = len(self.frequencies)
-                freqs_sorted = np.sort(self.frequencies)
-                dfreq = np.median(np.diff(freqs_sorted))
-                freqs_extended = np.concatenate(
-                    [freqs_sorted - dfreq * nfreq, freqs_sorted]
+            if self.freq_padding:
+                # Pad frequencies to ensure adequate coverage of FoG kernel
+                freqs_new, nfreq_pad, nfreq_pad_raw, FoG_kernel_frac = (
+                    lssutil.pad_frequencies(
+                        self.frequencies,
+                        use_FoG_kernel=True,
+                        cosmology=cosmology,
+                        sigma_P=sigma_P,
+                        FoG_threshold=self.FoG_freq_padding_threshold,
+                        maxnum=self.FoG_freq_padding_maxnum,
+                    )
                 )
-
-                # Compute corresponding extended list of comoving-distance
-                # differences from lowest frequency in original list
-                dx_extended = cosmology.comoving_distance(freqs_extended)
-                dx_extended -= dx_extended[nfreq]
-
-                # Evaluate normalized FoG kernel at values in this list
-                # and evaluate cumulative sum
-                kernel_extended = lssutil.exponential_FoG_kernel_1d(
-                    dx_extended, sigma_P, normalize=True
-                )
-                kernel_cumsum = np.cumsum(kernel_extended)
-
-                # Find number of extra frequencies required to cover
-                # requested fraction of kernel integral
-                nfreq_pad = max(
-                    np.sum(kernel_cumsum > 1 - self.FoG_freq_padding_threshold) - nfreq,
-                    0,
-                )
-                if self.FoG_freq_padding_maxnum is not None:
-                    nfreq_pad = min(nfreq_pad, self.FoG_freq_padding_maxnum)
-
-                # Make new arrays of frequencies, redshifts, and comoving distances
-                freqs_new = np.concatenate(
-                    [
-                        freqs_sorted[0] - np.arange(1, nfreq_pad + 1)[::-1] * dfreq,
-                        freqs_sorted,
-                        freqs_sorted[-1] + np.arange(1, nfreq_pad + 1) * dfreq,
-                    ]
-                )
-                if not np.array_equal(freqs_sorted, self.frequencies):
-                    freqs_new = freqs_new[::-1]
-                redshift_new = units.nu21 / freqs_new - 1.0
-                xa = cosmology.comoving_distance(redshift_new)
-
                 self.log.info(
-                    f"Padded frequency range with {nfreq_pad} elements at each end"
+                    "Fraction of FoG kernel covered by "
+                    f"padded frequencies: {FoG_kernel_frac}"
                 )
+                if nfreq_pad != nfreq_pad_raw:
+                    self.log.info(
+                        "Number of raw padding frequencies, "
+                        f"prior to cutting off: {nfreq_pad_raw}"
+                    )
 
-        else:
-            sigma_P = None
+        # If necessary, generate new comoving-distance array from padded frequencies
+        if nfreq_pad > 0:
+            redshift_new = units.nu21 / freqs_new - 1.0
+            xa = cosmology.comoving_distance(redshift_new)
+
+            self.log.info(f"Number of padding frequencies: {nfreq_pad}")
 
         phi_label = "d2phi" if self.use_d2phi else "phi"
 

--- a/cora/signal/lss.py
+++ b/cora/signal/lss.py
@@ -256,6 +256,11 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     will be used instead of phi. (This is useful to simulating maps of
     the Kaiser redshift-space distortion term.)
 
+    If `FoG_convolve` is set, the integrand of the C_l expression will
+    be convolved with the position-space Finger-of-God damping kernel.
+    Sky maps generated with the output C_l will then include this
+    damping.
+
     Attributes
     ----------
     nside : int
@@ -265,12 +270,21 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     frequencies : np.ndarray
         The frequencies to evaulate at. Overrides redshift property if
         specified.
+    channel_method : str, one of ["gauss_legendre", "uniform"]
+        Method for integrating within radial bins: Gauss-Legendre quadrature
+        ("gauss-legendre") or a combination of Simpson's rule and the trapezoid rule
+        ("uniform") based on uniform sampling of the entire comoving-distance
+        range being considered. (The latter is needed for Finger-of-God damping
+        to be incorporated.)
     xromb : int, optional
-        Gauss-Legendre quadrature order for integrating C_ell over radial
-        bins. (Used Romberg integration in a previous version, hence the
-        name xromb.) xromb=0 turns off this integral. When dealing with
-        nonlinear matter power spectrum, for sub-percent accuracy up to
-        l ~ 1500, xromb = 3 is recommended. Default: 2.
+        The order for integrating within radial bins, related to the number of samples
+        within each bin by `2**xromb + 1`. This generates an exponentially increasing
+        amount of work, so increase carefully. Note that despite the parameter name
+        this no longer uses a Romberg integrator, but either a Gauss-Legendre
+        quadrature rule or a combination of Simpson's rule and the trapezoid rule,
+        depending on `channel_method`. xromb = 0 turns off this integral. When
+        dealing with a nonlinear matter power spectrum, for sub-percent accuracy
+        up to l ~ 1500 with nside = 1024, xromb = 3 is recommended. Default: 2.
     leg_q : int, optional
         Integration accuracy parameter for Legendre transform for C_ell
         computation. When dealing with nonlinear matter power spectrum,
@@ -286,16 +300,48 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
     use_d2phi : bool, optional
         Compute spectra corresponding to the second line-of-sight
         derivative of phi instead of phi itself. Default: False.
+    FoG_convolve : bool, optional
+        Whether to convolve the integrand with the Finger-of-God damping kernel
+        prior to integration. Must choose `channel_method = "uniform"`.
+        Default: False.
+    alpha_FoG : float
+        A parameter to control the strength of the effect by adjusting the damping
+        scale. A value of 1 (default) applies the nominal damping, 0 turns the
+        damping off entirely, and any other values adjust the scale appropriately.
+    FoG_model : str, optional
+        Use an inbuilt model for the Finger-of-God damping. If None (default), a
+        specific model is expected to be set via `FoG_coeff` and `z_eff`. See
+        `lssmodels.sigma_P` for available models and details about them.
+    FoG_coeff : list, optional
+        A list of coefficients in a polynomial of `FoG_coeff[i] * (z - z_eff)**i`.
+        If None (default), `FoG_model` must be set.
+    FoG_z_eff : float, optional
+        The effective redshift of the polynomial expansion. Default: None.
+    FoG_z_eval : float, optional
+        Redshift at which to evaluate FoG damping model. If not set, mean redshift
+        of input container is used. Default: None.
     """
 
     nside = config.Property(proptype=int)
     redshift = config.Property(proptype=lssutil.linspace, default=None)
     frequencies = config.Property(proptype=lssutil.linspace, default=None)
+
+    channel_method = config.enum(
+        ["gauss-legendre", "uniform"], default="gauss-legendre"
+    )
     xromb = config.Property(proptype=int, default=2)
     leg_q = config.Property(proptype=int, default=4)
     leg_chunksize = config.Property(proptype=int, default=50)
     corrfunc_interp_type = config.enum(_INTERP_TYPES, default=None)
+
     use_d2phi = config.Property(proptype=bool, default=False)
+
+    FoG_convolve = config.Property(proptype=bool, default=False)
+    alpha_FoG = config.Property(proptype=float, default=1.0)
+    FoG_model = config.enum(lssmodels.sigma_P.models(), default=None)
+    FoG_coeff = config.list_type(type_=float, default=None)
+    FoG_z_eff = config.Property(proptype=float, default=None)
+    FoG_z_eval = config.Property(proptype=float, default=None)
 
     def process(
         self, correlation_functions: CorrelationFunction
@@ -334,6 +380,38 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
         # power will alias back down when the map is transformed later on
         lmax = 3 * self.nside - 1
 
+        # If alpha_FoG is 0, don't do FoG convolution even if requested
+        # by user
+        if self.alpha_FoG == 0:
+            self.FoG_convolve = False
+
+        # If using FoG, initialize fiducial model for damping scale.
+        if self.FoG_convolve:
+
+            if self.FoG_z_eval is not None:
+                z_eval = self.FoG_z_eval
+            else:
+                z_eval = np.mean(redshift)
+
+            if self.FoG_z_eff is not None and self.FoG_coeff is not None:
+
+                def s(z):
+                    return lssmodels.PolyModelSet.evaluate_poly(
+                        z, self.FoG_z_eff, self.FoG_coeff
+                    )
+
+                sigma_P = self.alpha_FoG * s(z_eval)
+
+            elif self.FoG_model is not None:
+                sigma_P = lssmodels.sigma_P[self.FoG_model](z_eval)
+            else:
+                raise config.CaputConfigError(
+                    "Either `FoG_model` must be set, or `FoG_z_eff` and `FoG_coeff`"
+                )
+
+        else:
+            sigma_P = None
+
         phi_label = "d2phi" if self.use_d2phi else "phi"
 
         self.log.debug("Generating C_l(x, x') for delta-delta")
@@ -344,6 +422,9 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             xromb=self.xromb,
             q=self.leg_q,
             chunksize=self.leg_chunksize,
+            channel_method=self.channel_method,
+            FoG_convolve=self.FoG_convolve,
+            FoG_sigmaP=sigma_P,
         )
 
         self.log.debug(f"Generating C_l(x, x') for {phi_label}-delta")
@@ -354,6 +435,9 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             xromb=self.xromb,
             q=self.leg_q,
             chunksize=self.leg_chunksize,
+            channel_method=self.channel_method,
+            FoG_convolve=self.FoG_convolve,
+            FoG_sigmaP=sigma_P,
             chi1_2nd_derivative=self.use_d2phi,
         )
 
@@ -365,6 +449,9 @@ class CalculateMultiFrequencyAngularPowerSpectrum(tasklib.base.ContainerTask):
             xromb=self.xromb,
             q=self.leg_q,
             chunksize=self.leg_chunksize,
+            channel_method=self.channel_method,
+            FoG_convolve=self.FoG_convolve,
+            FoG_sigmaP=sigma_P,
             chi1_2nd_derivative=self.use_d2phi,
             chi2_2nd_derivative=self.use_d2phi,
         )

--- a/cora/signal/lsscontainers.py
+++ b/cora/signal/lsscontainers.py
@@ -370,12 +370,14 @@ class MultiFrequencyAngularPowerSpectrum(FZXContainer):
         lmax: float,
         *args,
         d2phi: Optional[bool] = False,
+        nfreq_pad: Optional[int] = 0,
         **kwargs,
     ):
         # Set ell axis to span from ell=0 to lmax
         kwargs["ell"] = lmax + 1
         super().__init__(*args, **kwargs)
         self.attrs["d2phi"] = d2phi
+        self.attrs["nfreq_pad"] = nfreq_pad
 
     _dataset_spec = {
         "Cl_phi_phi": {
@@ -428,6 +430,14 @@ class MultiFrequencyAngularPowerSpectrum(FZXContainer):
             return False
         else:
             return self.attrs["d2phi"]
+
+    @property
+    def nfreq_pad(self) -> int:
+        """Number of padding frequencies used when computing spectra."""
+        if "nfreq_pad" not in self.attrs.keys():
+            return 0
+        else:
+            return self.attrs["nfreq_pad"]
 
 
 class InitialLSS(FZXContainer, HealpixContainer):

--- a/cora/signal/lsscontainers.py
+++ b/cora/signal/lsscontainers.py
@@ -592,7 +592,7 @@ class InitialLSS(FZXContainer, HealpixContainer):
 
         This is related to the linear gravitational potential :math:`\phi_G` by:
 
-        .. math:: \phi = \frac{3}{3 \mathcal{H}^2} \phi_G
+        .. math:: \phi = \frac{2}{3 \mathcal{H}^2} \phi_G
 
         If `d2phi` is set, the second radial derivative of phi is stored,
         rather than phi itself.

--- a/cora/signal/lsscontainers.py
+++ b/cora/signal/lsscontainers.py
@@ -440,6 +440,110 @@ class MultiFrequencyAngularPowerSpectrum(FZXContainer):
             return self.attrs["nfreq_pad"]
 
 
+class MultiTracerMultiFrequencyAngularPowerSpectrum(FZXContainer):
+    """Container for holding C_ell(chi,chi') for correlated tracers."""
+
+    _axes = (
+        "auto",
+        "cross",
+        "ell",
+    )
+
+    def __init__(
+        self,
+        lmax: float,
+        *args,
+        n_tracer: Optional[int] = 1,
+        d2phi: Optional[bool] = False,
+        nfreq_pad: Optional[int] = 0,
+        **kwargs,
+    ):
+        # Set ell axis to span from ell=0 to lmax
+        kwargs["ell"] = lmax + 1
+
+        # Set auto and cross axes to count number of distinct
+        # delta-delta/phi-phi and phi-delta spectra.
+        # Any code that uses this container must define its
+        # own conventions for which index maps to which
+        # spectrum.
+        kwargs["auto"] = n_tracer * (n_tracer + 1) // 2
+        kwargs["cross"] = n_tracer**2
+
+        super().__init__(*args, **kwargs)
+        self.attrs["d2phi"] = d2phi
+        self.attrs["nfreq_pad"] = nfreq_pad
+
+    _dataset_spec = {
+        "Cl_phi_phi": {
+            "axes": ["auto", "ell", "chi", "chi"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "ell",
+        },
+        "Cl_phi_delta": {
+            "axes": ["cross", "ell", "chi", "chi"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "ell",
+        },
+        "Cl_delta_delta": {
+            "axes": ["auto", "ell", "chi", "chi"],
+            "dtype": np.float64,
+            "initialise": True,
+            "distributed": True,
+            "distributed_axis": "ell",
+        },
+    }
+
+    @property
+    def Cl_phi_phi(self):
+        """Phi-phi angular power spectrum."""
+        return self.datasets["Cl_phi_phi"]
+
+    @property
+    def Cl_phi_delta(self):
+        """Phi-delta angular power spectrum."""
+        return self.datasets["Cl_phi_delta"]
+
+    @property
+    def Cl_delta_delta(self):
+        """Delta-delta angular power spectrum."""
+        return self.datasets["Cl_delta_delta"]
+
+    @property
+    def auto(self):
+        """Indices for stored delta-delta or phi-phi spectra."""
+        return self.index_map["auto"]
+
+    @property
+    def cross(self):
+        """Indices for stored phi-delta spectra."""
+        return self.index_map["cross"]
+
+    @property
+    def ell(self):
+        """Ell values for stored angular power spectra."""
+        return self.index_map["ell"]
+
+    @property
+    def d2phi(self) -> bool:
+        """Whether phi is actually the 2nd radial derivative of phi."""
+        if "d2phi" not in self.attrs.keys():
+            return False
+        else:
+            return self.attrs["d2phi"]
+
+    @property
+    def nfreq_pad(self) -> int:
+        """Number of padding frequencies used when computing spectra."""
+        if "nfreq_pad" not in self.attrs.keys():
+            return 0
+        else:
+            return self.attrs["nfreq_pad"]
+
+
 class InitialLSS(FZXContainer, HealpixContainer):
     """Container for holding initial LSS fields used for simulation.
 

--- a/cora/signal/lsscontainers.py
+++ b/cora/signal/lsscontainers.py
@@ -369,11 +369,13 @@ class MultiFrequencyAngularPowerSpectrum(FZXContainer):
         self,
         lmax: float,
         *args,
+        d2phi: Optional[bool] = False,
         **kwargs,
     ):
         # Set ell axis to span from ell=0 to lmax
         kwargs["ell"] = lmax + 1
         super().__init__(*args, **kwargs)
+        self.attrs["d2phi"] = d2phi
 
     _dataset_spec = {
         "Cl_phi_phi": {
@@ -419,12 +421,29 @@ class MultiFrequencyAngularPowerSpectrum(FZXContainer):
         """Ell values for stored angular power spectra."""
         return self.index_map["ell"]
 
+    @property
+    def d2phi(self) -> bool:
+        """Whether phi is actually the 2nd radial derivative of phi."""
+        if "d2phi" not in self.attrs.keys():
+            return False
+        else:
+            return self.attrs["d2phi"]
+
 
 class InitialLSS(FZXContainer, HealpixContainer):
     """Container for holding initial LSS fields used for simulation.
 
     These fields are all implicitly the linear fields at redshift z=0.
     """
+
+    def __init__(
+        self,
+        *args,
+        d2phi: Optional[bool] = False,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.attrs["d2phi"] = d2phi
 
     _dataset_spec = {
         "delta": {
@@ -460,8 +479,19 @@ class InitialLSS(FZXContainer, HealpixContainer):
         This is related to the linear gravitational potential :math:`\phi_G` by:
 
         .. math:: \phi = \frac{3}{3 \mathcal{H}^2} \phi_G
+
+        If `d2phi` is set, the second radial derivative of phi is stored,
+        rather than phi itself.
         """
         return self.datasets["phi"]
+
+    @property
+    def d2phi(self) -> bool:
+        """Whether phi is actually the 2nd radial derivative of phi."""
+        if "d2phi" not in self.attrs.keys():
+            return False
+        else:
+            return self.attrs["d2phi"]
 
 
 class BiasedLSS(FZXContainer, HealpixContainer):

--- a/cora/signal/lssmodels.py
+++ b/cora/signal/lssmodels.py
@@ -182,7 +182,7 @@ class omega_HI(PolyModelSet):
 
 
 class sigma_P(PolyModelSet):
-    """Models for the virial velocity scale in Mpc/h.
+    r"""Models for the virial velocity scale in Mpc/h.
 
     Notes
     -----

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -524,7 +524,8 @@ def integrate_uniform_into_bins(
     x: np.ndarray,
     xedges: np.ndarray,
     axis: Optional[int] = -1,
-    mean: Optional[bool] = False,
+    norm: Optional[np.ndarray] = None,
+    window: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """Integrate a uniformly-sampled function into bins with arbitrary edges.
 
@@ -532,6 +533,11 @@ def integrate_uniform_into_bins(
     samples falling within each bin, and then uses the trapezoid
     rule to add the contributions between the lowest/highest samples
     per bin and the bin boundaries.
+
+    The user can optionally provide an array of window function values
+    that the function should be multiplied by prior to integration.
+    (The hybrid Simpson-trapezoid scheme does not work if the product
+    of the window and function is passed directly to this routine.)
 
     X values and bin edges must be strictly increasing.
 
@@ -545,15 +551,21 @@ def integrate_uniform_into_bins(
         Edges of bins to integrate within.
     axis
         Axis to integrate over.
-    mean
-        Whether to compute the mean of the function over each bin (True)
-        or the integral (False).
+    norm
+        Array of values to divide each bin by after integration.
+        If no window is used, passing `norm=np.diff(xedges)` will
+        compute the mean over each bin. Default: None.
+    window
+        Array of window function values. Must have the same shape as `x`.
 
     Returns
     -------
     y_int
         Bin-integrated function.
     """
+
+    if window is None:
+        window = np.ones_like(x)
 
     nbins = len(xedges) - 1
     dx = x[1] - x[0]
@@ -569,8 +581,9 @@ def integrate_uniform_into_bins(
     idx_lo = np.searchsorted(x, xedges[:-1], side="left")
     idx_hi = np.concatenate([idx_lo[1:] - 1, [len(x) - 1]])
 
-    # Perform cumulative Simpson integration over full x range
-    y_int = si.cumulative_simpson(y, x=x, axis=-1, initial=0)
+    # Perform cumulative Simpson integration over full x range, with
+    # the integrand multiplied by the window if one is provided.
+    y_int = si.cumulative_simpson(y * window, x=x, axis=-1, initial=0)
 
     # Compute differences between cumulative-integral values at indices
     # corresponding to highest and lowest x values within each bin, to obtain
@@ -583,6 +596,9 @@ def integrate_uniform_into_bins(
     # to estimate the y values at the bin boundaries, excluding the
     # lower boundary of the lowest bin and the upper boundary of the higest
     # bin (since they correspond to the first and last y samples).
+    # This interpolation is done on the unwindowed function values, because
+    # the window may vary more rapidly than the function, and this would
+    # make interpolation of the windowed function unreliable.
     y_at_bounds = (
         y[..., idx_lo[1:]]
         - (y[..., idx_lo[1:]] - y[..., idx_lo[1:] - 1])
@@ -593,17 +609,23 @@ def integrate_uniform_into_bins(
     # We then use these interpolated y values, along with the y values
     # at the lowest and highest samples within the bin, to integrate
     # the missing edge contributions using the trapezoid rule, and add
-    # them to the results from above
+    # them to the results from above. If specified, the appropriate
+    # window values are incorporated here.
+    w_edge = window[0]
     y_int[..., 1:nbins] += (
-        0.5 * (x[idx_lo[1:]] - xedges[1:-1]) * (y_at_bounds + y[..., idx_lo[1:]])
+        0.5
+        * (x[idx_lo[1:]] - xedges[1:-1])
+        * (w_edge * y_at_bounds + window[idx_lo[1:]] * y[..., idx_lo[1:]])
     )
     y_int[..., : nbins - 1] += (
-        0.5 * (xedges[1:-1] - x[idx_hi[:-1]]) * (y_at_bounds + y[..., idx_hi[:-1]])
+        0.5
+        * (xedges[1:-1] - x[idx_hi[:-1]])
+        * (w_edge * y_at_bounds + window[idx_hi[:-1]] * y[..., idx_hi[:-1]])
     )
 
-    # If desired, divide by the bin widths to compute the mean
-    if mean:
-        y_int /= np.diff(xedges)
+    # Divide by normalization factors, if specified
+    if norm is not None:
+        y_int /= norm
 
     # Move integration axis back to original position
     return np.moveaxis(y_int, -1, axis)

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -12,6 +12,7 @@ from ..util import cubicspline as cs
 from ..util import hputil
 from ..util.nputil import FloatArrayLike
 from ..util import bilinearmap
+from ..util import cosmology as cora_cosmology
 
 
 def linspace(x: Union[dict, list, np.ndarray]) -> np.ndarray:
@@ -752,6 +753,119 @@ def exponential_FoG_kernel(
     K *= D[:, np.newaxis]
 
     return K
+
+
+def pad_frequencies(
+    frequencies: np.ndarray,
+    num: int = 1,
+    use_FoG_kernel: bool = False,
+    cosmology: cora_cosmology.Cosmology = None,
+    sigma_P: float = None,
+    FoG_threshold: float = 0.99,
+    maxnum: int = None,
+):
+    """Pad list of frequencies.
+
+    Input frequency list will be extended by an equal number of frequencies
+    at the high and low ends.
+
+    Parameters
+    ----------
+    frequencies
+        Array of frequencies to pad.
+    num
+        Number of frequencies to pad by. If determining padding using FoG
+        kernel, this number is treated as the minimum number of frequencies
+        to pad by.
+    use_FoG_kernel
+        Whether to use the FoG kernel to determine the number of padding
+        frequencies. The number of extra frequencies is computed such that the
+        FoG convolution for lowest frequency in the input list captures
+        contributions from some fraction of the integral of the FoG kernel,
+        specified by `FoG_threshold`.
+    cosmology
+        Cosmology object to use for computing comoving distances.
+    sigma_P
+        FoG damping scale for kernel.
+    FoG_threshold
+        See description of `use_FoG_kernel`.
+    maxnum
+        Maximum number of padding frequencies.
+
+    Returns
+    -------
+    padded_frequencies
+        Padded list of frequencies.
+    n_pad
+        Number of frequencies added at each end of input list.
+    n_pad_raw
+        Number of frequencies that would have been if `maxnum` was not set.
+    kernel_frac
+        Fraction of kernel integral covered by padded frequencies at lowest
+        input frequency. (Can be compared with `FoG_threshold` to determine
+        how much of the kernel was cut off by the specified `maxnum`.)
+    """
+
+    if use_FoG_kernel and ((cosmology is None) or (sigma_P is None)):
+        raise RuntimeError(
+            "If using FoG kernel to determine padding, "
+            "cosmology and sigmaP must both be specified"
+        )
+
+    # Sort frequencies and find spacing
+    nfreq = len(frequencies)
+    freqs_sorted = np.sort(frequencies)
+    dfreq = np.median(np.diff(freqs_sorted))
+
+    if not use_FoG_kernel:
+        n_pad_raw = num
+        n_pad = num
+        kernel_frac = 1.0
+    else:
+        # Generate list of frequencies that's extended by a factor
+        # of 2 at the low end
+        freqs_extended = np.concatenate([freqs_sorted - nfreq * dfreq, freqs_sorted])
+
+        # Compute corresponding extended list of comoving-distance
+        # differences from lowest frequency in original list
+        dx_extended = cosmology.comoving_distance(freqs_extended)
+        dx_extended -= dx_extended[nfreq]
+
+        # Evaluate normalized FoG kernel at values in this list
+        # and evaluate cumulative sum
+        kernel_extended = exponential_FoG_kernel_1d(
+            dx_extended, sigma_P, normalize=True
+        )
+        kernel_cumsum = np.cumsum(kernel_extended)
+
+        # Find number of extra frequencies required to cover
+        # requested fraction of kernel integral
+        n_pad_raw = max(
+            np.sum(kernel_cumsum > 1 - FoG_threshold) - nfreq,
+            0,
+        )
+        if maxnum is None:
+            maxnum = nfreq + 1
+        n_pad = min(n_pad_raw, maxnum)
+
+        # Save fraction of kernel covered by padded frequencies
+        # at lowest input frequency
+        kernel_frac = (1 - kernel_cumsum)[nfreq - n_pad]
+
+    # Make new frequency list
+    padded_frequencies = np.concatenate(
+        [
+            freqs_sorted[0] - np.arange(1, n_pad + 1)[::-1] * dfreq,
+            freqs_sorted,
+            freqs_sorted[-1] + np.arange(1, n_pad + 1) * dfreq,
+        ]
+    )
+
+    # Reverse order if initial sorting had an effect
+    if not np.array_equal(padded_frequencies, frequencies):
+        padded_frequencies = padded_frequencies[::-1]
+
+    return padded_frequencies, n_pad, n_pad_raw, kernel_frac
 
 
 def lognormal_transform(

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -703,17 +703,17 @@ class Pk2d_to_Cl:
     """
 
     def __init__(
-        self, 
+        self,
         pk2d,
         chi_of_z,
-        kparmax=50.,
+        kparmax=50.0,
         nkpar=32768,
         kperpmin=1e-4,
         kperpmax=40.0,
         nkperp=500,
         k_meshgrid=True,
     ):
-        
+
         self.kparmax = kparmax
         self.nkpar = nkpar
         self.kperpmin = kperpmin
@@ -725,7 +725,7 @@ class Pk2d_to_Cl:
         kpar = np.linspace(0, kparmax, nkpar)
 
         if k_meshgrid:
-            kperp, kpar = np.meshgrid(kperp, kpar, indexing='ij')
+            kperp, kpar = np.meshgrid(kperp, kpar, indexing="ij")
         else:
             kperp = kperp[:, np.newaxis]
             kpar = kpar[np.newaxis, :]

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -3,6 +3,7 @@ from typing import Callable, Union, Tuple, Optional
 import numpy as np
 from scipy.fftpack import dct
 import scipy.integrate as si
+import scipy.sparse as ssparse
 
 import healpy
 
@@ -629,6 +630,183 @@ def integrate_uniform_into_bins(
 
     # Move integration axis back to original position
     return np.moveaxis(y_int, -1, axis)
+
+
+def integrate_uniform_into_tapered_channels(
+    y: np.ndarray,
+    x: np.ndarray,
+    xcenters: np.ndarray,
+    xwidths: np.ndarray,
+    channel_profile: Callable[[np.ndarray], np.ndarray],
+    axis: Optional[int] = -1,
+    n_overlap: Optional[int] = 1,
+    use_cached_weights: Optional[bool] = False,
+):
+    """Integrate a uniformly-sampled function into channels with tapered profiles.
+
+    This function uses Simpson's rule to integrate a uniformly-sampled
+    function against a set of identical profiles defined with respect
+    to a list of profile centers. The profile must taper smoothly to
+    a small amplitude, such that the results are not sensitive to
+    the precise integration bounds as long as they enclose most of
+    the profile's support. The profiles are allowed to overlap; otherwise,
+    `integrate_uniform_into_bins` should be used instead.
+
+    X values and centers must be strictly increasing.
+
+    The integration weights can be cached and re-used in subsequent
+    calls if `use_cached_weights` is set. The weights will be recomputed
+    if the function is evaluated with different coordinate arguments
+    or a different profile.
+
+    Parameters
+    ----------
+    y
+        Function values on uniform grid.
+    x
+        Grid values on which function was evaluated.
+    xcenters
+        Coordinates of channel centers. These values don't need
+        to be elements of `x`.
+    xwidths
+        Coordinate widths of each channel.
+    channel_profile
+        Channel profile to use in the channel integration.
+        The profile function must be defined in terms of coordinate relative
+        to channel center, in units of channel width (e.g. center = 0,
+        edges = [-0.5, 0.5]). The profile can extend beyond the
+        channel width, but is still defined relative to this width.
+    axis
+        Axis to integrate over.
+    n_overlap
+        Number of channels on either side of the channel of interest
+        to integrate over. Should be chosen to cover most of profile's
+        support.
+    use_cached_weights
+        Store integration weights for subsequent re-use if function is
+        called again with same coordinate arguments and profile.
+
+    Returns
+    -------
+    y_int
+        Bin-integrated function.
+    """
+
+    nx = len(x)
+    dx = x[1] - x[0]
+    nchan = len(xcenters)
+
+    if not use_cached_weights or not hasattr(
+        integrate_uniform_into_tapered_channels, "_weights"
+    ):
+        recompute_weights = True
+    else:
+        recompute_weights = (
+            not np.isclose(integrate_uniform_into_tapered_channels._x0, x[0])
+            or not np.isclose(integrate_uniform_into_tapered_channels._dx, dx)
+            or integrate_uniform_into_tapered_channels._nx != nx
+            or not np.allclose(
+                integrate_uniform_into_tapered_channels._xcenters, xcenters
+            )
+            or not np.allclose(
+                integrate_uniform_into_tapered_channels._xwidths, xwidths
+            )
+            or integrate_uniform_into_tapered_channels._channel_profile
+            is not channel_profile
+            or integrate_uniform_into_tapered_channels._n_overlap != n_overlap
+        )
+
+    # Generate weights for each channel integral, if not cached
+    # and/or not using cache
+    if recompute_weights:
+
+        # Compute channel edges based on centers and widths
+        xedges = np.concatenate(
+            [xcenters - 0.5 * xwidths, [xcenters[-1] + 0.5 * xwidths[-1]]]
+        )
+
+        # Determine the channel index of each point in x
+        chan_idx = np.searchsorted(xedges, x, side="right") - 1
+        chan_idx = np.clip(chan_idx, 0, nx - 1)
+
+        # Create arrays for building sparse weight array
+        weight_vals = []
+        weight_idx = []
+        weight_idxptr = [0]
+
+        # Loop over channels
+        for c in range(nchan):
+            # Find indices of elements in x that are within
+            # n_overlap channels of current channel
+            x_mask = (chan_idx >= c - n_overlap) & (chan_idx <= c + n_overlap)
+            x_idx = np.where(x_mask)[0]
+
+            # Ensure set of indices has odd length (so we can apply
+            # Simpson's rule). If even, remove lowest index from set.
+            # As long as we're probing far enough into the tail of
+            # the channel profile, this should incur a small amount
+            # of numerical error.
+            if len(x_idx) % 2 == 0:
+                x_idx = x_idx[1:]
+
+            # Compute distance of each point from center of current
+            # channel, divided by the channel width
+            rel_dx_full = (x[x_idx] - xcenters[c]) / xwidths[c]
+
+            # Evaluate the channel profile at these values
+            w = channel_profile(rel_dx_full)
+
+            # Multiply channel profile by Simpson-rule weights:
+            # [1, 4, 2, 4, ..., 1] * dx / 3
+            w[1:-1:2] *= 4
+            w[2:-1:2] *= 2
+            w *= dx / 3
+
+            # Integrate channel profile within each channel, using
+            # Simpson's rule, and use this to normalize the weights.
+            # (This ensures that the final integrals are means over
+            # each channel's profile.)
+            norm = np.sum(w)
+            w /= norm
+
+            # Store weights and indices in format appropriate for
+            # sparse (CSR) array
+            weight_vals.append(w)
+            weight_idx.append(x_idx)
+            weight_idxptr.append(weight_idxptr[-1] + len(x_idx))
+
+        # Concatenate weight values and index arrays
+        weight_vals = np.concatenate(weight_vals)
+        weight_idx = np.concatenate(weight_idx)
+
+        # Construct sparse array of weights
+        integrate_uniform_into_tapered_channels._weights = ssparse.csr_array(
+            (weight_vals, weight_idx, weight_idxptr), dtype=np.float64
+        )
+
+        # Save relevant input arguments
+        integrate_uniform_into_tapered_channels._x0 = x[0]
+        integrate_uniform_into_tapered_channels._dx = dx
+        integrate_uniform_into_tapered_channels._nx = nx
+        integrate_uniform_into_tapered_channels._xcenters = xcenters
+        integrate_uniform_into_tapered_channels._xwidths = xwidths
+        integrate_uniform_into_tapered_channels._channel_profile = channel_profile
+        integrate_uniform_into_tapered_channels._n_overlap = n_overlap
+
+    # Move integration axis to the beginning, in preparation for multiplication
+    # by sparse array
+    axis = axis % y.ndim
+    y = np.moveaxis(y, axis, 0)
+    shp = y.shape
+
+    # Multiply y by matrix of weights. In the result, the first axis is
+    # channel number. Need to first reshape y, because only 2d x 2d matrix
+    # multiplication is supported for sparse arrays.
+    y_int = integrate_uniform_into_tapered_channels._weights @ y.reshape(shp[0], -1)
+    y_int = y_int.reshape((y_int.shape[0],) + shp[1:])
+
+    # Move channel axis back to original position
+    return np.moveaxis(y_int, 0, axis)
 
 
 def exponential_FoG_kernel_1d(

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -608,6 +608,50 @@ def integrate_uniform_into_bins(
     return np.moveaxis(y_int, -1, axis)
 
 
+def exponential_FoG_kernel_1d(
+    dchi: np.ndarray,
+    sigmaP: float,
+    cut: Optional[float] = 1e-5,
+    normalize: Optional[bool] = False,
+) -> np.ndarray:
+    """Compute analytical position-space Finger-of-God kernel.
+
+    Parameters
+    ----------
+    dchi
+        Comoving distance differences at which to evaluate kernel.
+    sigmaP
+        Damping scale parameter.
+    cut
+        Only compute kernel values that are above this fraction of the maximum
+        kernel value (to avoid underflow errors). Zeros are returned for lower
+        values.
+    normalize
+        Whether to normalize the returned kernel values by their sum.
+
+    Returns
+    -------
+    kernel
+        Array of kernel values evaluated at input dchi values.
+    """
+    a = 2**0.5 / sigmaP
+    denom = a * sigmaP**2
+
+    kernel = np.zeros_like(dchi, dtype=np.float64)
+
+    # Make mask that selects kernel values above cut
+    arg = a * np.abs(dchi)
+    mask = arg <= -np.log(cut)
+
+    # Compute relevant kernel values
+    kernel[mask] = np.exp(-arg[mask]) / denom
+
+    if normalize:
+        kernel[mask] /= np.sum(kernel[mask])
+
+    return kernel
+
+
 def exponential_FoG_kernel(
     chi: np.ndarray,
     sigmaP: FloatArrayLike,

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -2,6 +2,7 @@ from typing import Callable, Union, Tuple, Optional
 
 import numpy as np
 from scipy.fftpack import dct
+import scipy.integrate as si
 
 import healpy
 
@@ -515,6 +516,96 @@ def calculate_width(centres: np.ndarray) -> np.ndarray:
     widths[-1] = 2 * (centres[-1] - (widths[-2] / 2.0) - centres[-2])
 
     return np.abs(widths)
+
+
+def integrate_uniform_into_bins(
+    y: np.ndarray,
+    x: np.ndarray,
+    xedges: np.ndarray,
+    axis: Optional[int] = -1,
+    mean: Optional[bool] = False,
+) -> np.ndarray:
+    """Integrate a uniformly-sampled function into bins with arbitrary edges.
+
+    This function uses Simpson's rule to integrate over the
+    samples falling within each bin, and then uses the trapezoid
+    rule to add the contributions between the lowest/highest samples
+    per bin and the bin boundaries.
+
+    X values and bin edges must be strictly increasing.
+
+    Parameters
+    ----------
+    y
+        Function values on uniform grid.
+    x
+        Grid values on which function was evaluated.
+    xedges
+        Edges of bins to integrate within.
+    axis
+        Axis to integrate over.
+    mean
+        Whether to compute the mean of the function over each bin (True)
+        or the integral (False).
+
+    Returns
+    -------
+    y_int
+        Bin-integrated function.
+    """
+
+    nbins = len(xedges) - 1
+    dx = x[1] - x[0]
+
+    # Move integration axis to the end, to make slicing easier
+    axis = axis % y.ndim
+    y = np.moveaxis(y, axis, -1)
+
+    # Determine array indices corresponding to x values that are
+    # just above each lower bin boundary and just below each upper
+    # bin boundary. (The lowest idx_lo and highest idx_hi
+    # indices will correspond to lowest and highest bin boundaries.)
+    idx_lo = np.searchsorted(x, xedges[:-1], side="left")
+    idx_hi = np.concatenate([idx_lo[1:] - 1, [len(x) - 1]])
+
+    # Perform cumulative Simpson integration over full x range
+    y_int = si.cumulative_simpson(y, x=x, axis=-1, initial=0)
+
+    # Compute differences between cumulative-integral values at indices
+    # corresponding to highest and lowest x values within each bin, to obtain
+    # integrals over samples that lie solely within each bin.
+    y_int = y_int[..., idx_hi] - y_int[..., idx_lo]
+
+    # The above differences will miss contributions to each bin integral
+    # between the lowest/highest samples and the bin boundaries.
+    # To incorporate these contributions, we first use linear interpolation
+    # to estimate the y values at the bin boundaries, excluding the
+    # lower boundary of the lowest bin and the upper boundary of the higest
+    # bin (since they correspond to the first and last y samples).
+    y_at_bounds = (
+        y[..., idx_lo[1:]]
+        - (y[..., idx_lo[1:]] - y[..., idx_lo[1:] - 1])
+        * (x[idx_lo[1:]] - xedges[1:-1])
+        / dx
+    )
+
+    # We then use these interpolated y values, along with the y values
+    # at the lowest and highest samples within the bin, to integrate
+    # the missing edge contributions using the trapezoid rule, and add
+    # them to the results from above
+    y_int[..., 1:nbins] += (
+        0.5 * (x[idx_lo[1:]] - xedges[1:-1]) * (y_at_bounds + y[..., idx_lo[1:]])
+    )
+    y_int[..., : nbins - 1] += (
+        0.5 * (xedges[1:-1] - x[idx_hi[:-1]]) * (y_at_bounds + y[..., idx_hi[:-1]])
+    )
+
+    # If desired, divide by the bin widths to compute the mean
+    if mean:
+        y_int /= np.diff(xedges)
+
+    # Move integration axis back to original position
+    return np.moveaxis(y_int, -1, axis)
 
 
 def exponential_FoG_kernel(

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -516,7 +516,10 @@ def calculate_width(centres: np.ndarray) -> np.ndarray:
 
 
 def exponential_FoG_kernel(
-    chi: np.ndarray, sigmaP: FloatArrayLike, D: FloatArrayLike
+    chi: np.ndarray,
+    sigmaP: FloatArrayLike,
+    D: FloatArrayLike,
+    full_channel_kernel: bool = False,
 ) -> np.ndarray:
     r"""Get a smoothing kernel for approximating Fingers of God.
 
@@ -556,11 +559,13 @@ def exponential_FoG_kernel(
 
     # This is the main parameter of the exponential kernel and comes from the FT of the
     # canonically defined Lorentzian
-    a = 2**0.5 / sigmaP
-    ar = a[:, np.newaxis]
+    a_1D = 2**0.5 / sigmaP
+    a_r = a_1D[:, np.newaxis]
 
     # Get bin widths for the radial axis
-    dchi = calculate_width(chi)[np.newaxis, :]
+    dchi_1D = calculate_width(chi)
+    dchi_r = dchi_1D[:, np.newaxis]
+    dchi_rp = dchi_1D[np.newaxis, :]
 
     chi_sep = np.abs(chi[:, np.newaxis] - chi[np.newaxis, :])
 
@@ -568,14 +573,31 @@ def exponential_FoG_kernel(
         return np.sinh(x) / x
 
     # Create a matrix to apply the smoothing with an exponential kernel.
-    # NOTE: because of the finite radial bins we should calculate the average
-    # contribution over the width of each bin. That gives rise to the sinhc terms which
-    # slightly boost the weights of the non-zero bins
-    K = np.exp(-ar * chi_sep) * sinhc(ar * dchi / 2.0)
+    if full_channel_kernel:
+        K = (
+            (2.0 / dchi_rp)
+            * np.exp(-a_r * chi_sep)
+            * np.sinh(a_r * dchi_r / 2.0)
+            * np.sinh(a_r * dchi_rp / 2.0)
+        )
+        np.fill_diagonal(
+            K,
+            a_1D
+            - (2.0 / dchi_1D)
+            * np.exp(-a_1D * dchi_1D / 2.0)
+            * np.sinh(a_1D * dchi_1D / 2.0),
+        )
+    else:
+        # NOTE: because of the finite radial bins we should calculate the average
+        # contribution over the width of each bin. That gives rise to the sinhc terms which
+        # slightly boost the weights of the non-zero bins
+        K = np.exp(-a_r * chi_sep) * sinhc(a_r * dchi_rp / 2.0)
 
-    # The zero-lag bins are a special case because of the reflection about zero
-    # Here the weight is slightly less than if we evaluated exactly at zero
-    np.fill_diagonal(K, np.diagonal(np.exp(-ar * dchi / 4) * sinhc(ar * dchi / 4)))
+        # The zero-lag bins are a special case because of the reflection about zero
+        # Here the weight is slightly less than if we evaluated exactly at zero
+        np.fill_diagonal(
+            K, np.diagonal(np.exp(-a_r * dchi_rp / 4) * sinhc(a_r * dchi_rp / 4))
+        )
 
     # Normalise each row to ensure conservation of mass
     K /= np.sum(K, axis=1)[:, np.newaxis]

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -583,7 +583,7 @@ def integrate_uniform_into_bins(
 
     # Perform cumulative Simpson integration over full x range, with
     # the integrand multiplied by the window if one is provided.
-    y_int = si.cumulative_simpson(y * window, x=x, axis=-1, initial=0)
+    y_int = si.cumulative_simpson(y * window, dx=dx, axis=-1, initial=0)
 
     # Compute differences between cumulative-integral values at indices
     # corresponding to highest and lowest x values within each bin, to obtain

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -1,6 +1,7 @@
 from typing import Callable, Union, Tuple, Optional
 
 import numpy as np
+from scipy.fftpack import dct
 
 import healpy
 
@@ -9,6 +10,7 @@ from caput import algorithms, config
 from ..util import cubicspline as cs
 from ..util import hputil
 from ..util.nputil import FloatArrayLike
+from ..util import bilinearmap
 
 
 def linspace(x: Union[dict, list, np.ndarray]) -> np.ndarray:
@@ -666,3 +668,119 @@ def assert_shape(arr, shape, name):
         raise ValueError(
             f"Array {name} has the wrong shape (got {arr.shape}, expected {shape}"
         )
+
+
+class Pk2d_to_Cl:
+    """Converter from 2d power spectrum to multi-frequency angular power spectrum.
+
+    This class packages the algorithm from the angular_powerspectrum_fft
+    method from the cora.signal.corr.RedshiftCorrelation class in a
+    self-contained way, suitable for working with an externally-defined
+    power spectrum in terms of k_parallel and k_perp. These different
+    implementations should eventually be refactored, but will remain
+    separate for now.
+
+    Parameters
+    ----------
+    pk2d : function
+        Power spectrum function, with arguments (k_parallel, k_perp).
+    chi_of_z : function
+        Function to convert redshift to comoving distance.
+    kparmax : float, optional
+        Maximum k_parallel for integration. (Note that the minimum
+        k_parallel is 0.) Default: 50.
+    nkpar : int, optional
+        Number of k_parallel values to use in discrete cosine transform.
+        Default: 32768.
+    kperpmin, kperpmax : float, optional
+        Minimum and maximum k_perp values. These determine the minimum
+        and maximum ell values that are accessible. Default: 1e-4 and 40.
+    nkperp : int, optional
+        Number of k_perp values to interpolate between. Default: 500.
+    k_meshgrid : bool, optional
+        Whether pk2d function can accept (kpar, kperp) values evaluated
+        on a numpy meshgrid. Default: True.
+    """
+
+    def __init__(
+        self, 
+        pk2d,
+        chi_of_z,
+        kparmax=50.,
+        nkpar=32768,
+        kperpmin=1e-4,
+        kperpmax=40.0,
+        nkperp=500,
+        k_meshgrid=True,
+    ):
+        
+        self.kparmax = kparmax
+        self.nkpar = nkpar
+        self.kperpmin = kperpmin
+        self.kperpmax = kperpmax
+        self.nkperp = nkperp
+        self.chi_of_z = chi_of_z
+
+        kperp = np.logspace(np.log10(kperpmin), np.log10(kperpmax), nkperp)
+        kpar = np.linspace(0, kparmax, nkpar)
+
+        if k_meshgrid:
+            kperp, kpar = np.meshgrid(kperp, kpar, indexing='ij')
+        else:
+            kperp = kperp[:, np.newaxis]
+            kpar = kpar[np.newaxis, :]
+
+        dd = pk2d(kpar, kperp)
+
+        self.aps_cache = dct(dd, type=1) * kparmax / (2 * nkpar)
+
+    def eval(self, la, za1, za2, const_chi=False):
+        """Evaluate C_ell(z, z').
+
+        Parameters
+        ----------
+        la : array_like
+            Ell values to evaluate at.
+        za1, za2 : array_like
+            Redshifts to evaluate at
+        const_chi : bool, optional
+            Evaluate k-ell relationship and prefactor at
+            constant comoving distance. Default: False.
+
+        Returns
+        -------
+        cl : array_like
+            Array of C_ell(z, z') values.
+        """
+
+        xa1 = self.chi_of_z(za1)
+        xa2 = self.chi_of_z(za2)
+
+        xc = 0.5 * (xa1 + xa2)
+        if const_chi:
+            xc = np.mean(xc)
+        rpar = np.abs(xa2 - xa1)
+
+        # Bump anything that is zero upwards to avoid a log zero warning.
+        la = np.where(la == 0.0, 1e-10, la)
+
+        x = (
+            (np.log10(la) - np.log10(xc * self.kperpmin))
+            / np.log10(self.kperpmax / self.kperpmin)
+            * (self.nkperp - 1)
+        )
+        y = rpar / (np.pi / self.kparmax)
+
+        def _interp2d(arr, x, y):
+            x, y = np.broadcast_arrays(x, y)
+            sh = x.shape
+
+            x, y = x.flatten(), y.flatten()
+            v = np.zeros_like(x)
+            bilinearmap.interp(arr, x, y, v)
+
+            return v.reshape(sh)
+
+        psdd = _interp2d(self.aps_cache, x, y)
+
+        return 1 / (xc**2 * np.pi) * psdd

--- a/cora/signal/lssutil.py
+++ b/cora/signal/lssutil.py
@@ -531,6 +531,11 @@ def exponential_FoG_kernel(
         The smooth parameter for each radial bin.
     D
         The growth factor for each radial bin.
+    full_channel_kernel
+        Whether to integrate the continuous kernel over each radial bin for both
+        the "input" and "output" channel (True), or just the "input" channel
+        (False). The former is more correct, but the latter is the default for
+        legacy purposes. Default. False.
 
     Returns
     -------
@@ -574,6 +579,7 @@ def exponential_FoG_kernel(
 
     # Create a matrix to apply the smoothing with an exponential kernel.
     if full_channel_kernel:
+        # See CHIME doclib:XXXX for derivations of these expressions
         K = (
             (2.0 / dchi_rp)
             * np.exp(-a_r * chi_sep)

--- a/cora/util/cosmology.py
+++ b/cora/util/cosmology.py
@@ -130,7 +130,7 @@ class Cosmology(object):
         """
         h = H0 / 100.0
         H_si = H0 * 1000.0 / constants.mega_parsec
-        rhoc = 3.0 * H_si**2 * constants.c**2 / (8.0 * np.pi * constants.G_n)
+        rhoc = 3.0 * H_si**2 * constants.c**2 / (8.0 * np.pi * constants.G)
         rhorad = constants.a_rad * TCMB**4
         rhonu = nnu * rhorad * 7.0 / 8.0 * (4.0 / 11.0) ** (4.0 / 3.0)
         omkh2 = omk * h**2


### PR DESCRIPTION
This PR includes updates that were used for the auto spectrum interpretation paper and associated detection paper updates:
- Expanded functionality for `cora.core.skysim.clarray()`
- A `constant_redshift` option in a few routines in `cora.signal.corr` and `cora.signal.corr21cm`
- Expanded functionality for `cora.signal.corrfunc.corr_to_clarray()`
- New `cora.signal.lss.CalculatePFBChannelProfile` task
- Refactoring and expanded functionality for multi-frequency angular power spectrum tasks in `cora.signal.lss`
- New `cora.signal.lss.util.Pk2d_to_Cl` class. The design and location of this are a bit strange, and should eventually be refactored, but the current version works.
- Misc. other additions and improvements

The `sf/alt-fog` branch was actually used to generate the simulations for the papers, but is based on the pre-refactor versions of `radiocosmology` packages. This branch has been updated to work with the new packages, and I've run a few spot checks to verify that the outputs are consistent with those of the older branch.