### PR TITLE
Add fluxcat-based point source sky map tasks

### DIFF
--- a/cora/foreground/pointsource.py
+++ b/cora/foreground/pointsource.py
@@ -729,13 +729,7 @@ class FluxCatPointSources(maps.Map3d):
             sky
             * 1e-26
             * constants.c**2
-            / (
-                2
-                * constants.k_B
-                * freq[:, np.newaxis, np.newaxis] ** 2
-                * 1e12
-                * pxarea
-            )
+            / (2 * constants.k_B * freq[:, np.newaxis, np.newaxis] ** 2 * 1e12 * pxarea)
         )
 
         self._used_collections = [name for name, _ in FluxCatalog.loaded_collections()]
@@ -803,13 +797,7 @@ class SingleFluxCatSource(maps.Map3d):
             sky
             * 1e-26
             * constants.c**2
-            / (
-                2
-                * constants.k_B
-                * freq[:, np.newaxis, np.newaxis] ** 2
-                * 1e12
-                * pxarea
-            )
+            / (2 * constants.k_B * freq[:, np.newaxis, np.newaxis] ** 2 * 1e12 * pxarea)
         )
 
         self._used_collections = [name for name, _ in FluxCatalog.loaded_collections()]
@@ -874,13 +862,7 @@ class FluxCatCatalogMap(maps.Map3d):
             sky
             * 1e-26
             * constants.c**2
-            / (
-                2
-                * constants.k_B
-                * freq[:, np.newaxis, np.newaxis] ** 2
-                * 1e12
-                * pxarea
-            )
+            / (2 * constants.k_B * freq[:, np.newaxis, np.newaxis] ** 2 * 1e12 * pxarea)
         )
 
         self._used_collections = [name for name, _ in FluxCatalog.loaded_collections()]

--- a/cora/foreground/pointsource.py
+++ b/cora/foreground/pointsource.py
@@ -545,7 +545,9 @@ class CombinedPointSources(maps.Map3d):
         A = 3.55e-5
         nu_0 = 408.0
         l_0 = 100.0
-        oversample = 0  # disable oversampling for performance; not needed at this flux level
+        oversample = (
+            0  # disable oversampling for performance; not needed at this flux level
+        )
 
     class _RandomResolved(DiMatteo):
         flux_min = 0.1
@@ -613,7 +615,9 @@ class CombinedFluxCatPointSources(maps.Map3d):
         A = 3.55e-5
         nu_0 = 408.0
         l_0 = 100.0
-        oversample = 0  # disable oversampling for performance; not needed at this flux level
+        oversample = (
+            0  # disable oversampling for performance; not needed at this flux level
+        )
 
     class _RandomResolved(DiMatteo):
         flux_min = 0.1

--- a/cora/foreground/pointsource.py
+++ b/cora/foreground/pointsource.py
@@ -539,11 +539,13 @@ class CombinedPointSources(maps.Map3d):
 
     ## Internal classes for creating PS simulation
     class _UnresolvedBackground(gaussianfg.PointSources):
+        # SCK parameters (Santos, Cooray & Knox 2005, arXiv:astro-ph/0408515, Table 1)
+        # re-parameterized at nu_0=408 MHz (Haslam map frequency) and l_0=100, with
+        # amplitude A rescaled to represent only sources below the S < 0.1 Jy flux cut.
         A = 3.55e-5
         nu_0 = 408.0
         l_0 = 100.0
-
-        oversample = 0
+        oversample = 0  # disable oversampling for performance; not needed at this flux level
 
     class _RandomResolved(DiMatteo):
         flux_min = 0.1
@@ -590,7 +592,7 @@ class CombinedFluxCatPointSources(maps.Map3d):
 
     After calling :meth:`getpolsky`, the attribute ``_used_collections`` holds
     the list of fluxcat collection names that contributed to the map, which is
-    also written into the output HDF5 file as ``index_map/catalog``.
+    also written into the output HDF5 file as the ``catalog`` file attribute.
 
     Attributes
     ----------
@@ -605,10 +607,13 @@ class CombinedFluxCatPointSources(maps.Map3d):
     catalog_file = None
 
     class _UnresolvedBackground(gaussianfg.PointSources):
+        # SCK parameters (Santos, Cooray & Knox 2005, arXiv:astro-ph/0408515, Table 1)
+        # re-parameterized at nu_0=408 MHz (Haslam map frequency) and l_0=100, with
+        # amplitude A rescaled to represent only sources below the S < 0.1 Jy flux cut.
         A = 3.55e-5
         nu_0 = 408.0
         l_0 = 100.0
-        oversample = 0
+        oversample = 0  # disable oversampling for performance; not needed at this flux level
 
     class _RandomResolved(DiMatteo):
         flux_min = 0.1
@@ -662,7 +667,7 @@ class FluxCatPointSources(maps.Map3d):
 
     After calling :meth:`getpolsky`, the attribute ``_used_collections`` holds
     the list of fluxcat collection names that contributed to the map, which is
-    also written into the output HDF5 file as ``index_map/catalog``.
+    also written into the output HDF5 file as the ``catalog`` file attribute.
 
     Attributes
     ----------
@@ -745,7 +750,7 @@ class SingleFluxCatSource(maps.Map3d):
 
     After calling :meth:`getpolsky`, the attribute ``_used_collections`` holds
     the list of fluxcat collection names that contributed to the map, which is
-    also written into the output HDF5 file as ``index_map/catalog``.
+    also written into the output HDF5 file as the ``catalog`` file attribute.
 
     Attributes
     ----------
@@ -813,7 +818,7 @@ class FluxCatCatalogMap(maps.Map3d):
 
     After calling :meth:`getpolsky`, the attribute ``_used_collections`` holds
     the list of fluxcat collection names that contributed to the map, which is
-    also written into the output HDF5 file as ``index_map/catalog``.
+    also written into the output HDF5 file as the ``catalog`` file attribute.
 
     Attributes
     ----------

--- a/cora/foreground/pointsource.py
+++ b/cora/foreground/pointsource.py
@@ -576,3 +576,312 @@ class CombinedPointSources(maps.Map3d):
         ps_all += obj_real.getpolsky()
 
         return ps_all
+
+
+class CombinedFluxCatPointSources(maps.Map3d):
+    """Combined point source map using fluxcat for bright resolved sources.
+
+    Identical structure to :class:`CombinedPointSources` but replaces the
+    old real-source catalog with the fluxcat catalog above the flux cut:
+
+    - S < 0.1 Jy (at 151 MHz): Gaussian approximation for the unresolved background.
+    - 0.1 Jy < S < 4 Jy (at 600 MHz): synthetic DiMatteo population.
+    - S > 4 Jy (at 600 MHz): real sources from the fluxcat catalog.
+
+    After calling :meth:`getpolsky`, the attribute ``_used_collections`` holds
+    the list of fluxcat collection names that contributed to the map, which is
+    also written into the output HDF5 file as ``index_map/catalog``.
+
+    Attributes
+    ----------
+    flux_max : float or None
+        Maximum flux (in Jy at 600 MHz) to include. Default is None (no limit).
+    catalog_file : str or None
+        Path to an additional JSON catalog file to load into fluxcat before
+        generating the map. Default is None.
+    """
+
+    flux_max = None
+    catalog_file = None
+
+    class _UnresolvedBackground(gaussianfg.PointSources):
+        A = 3.55e-5
+        nu_0 = 408.0
+        l_0 = 100.0
+        oversample = 0
+
+    class _RandomResolved(DiMatteo):
+        flux_min = 0.1
+        flux_max = (
+            4.0 * (151.0 / 600.0) ** DiMatteo.spectral_mean
+        )  # Convert 4 Jy at 600 MHz to a flux cut at 151 MHz
+
+    def getsky(self):
+        """Simulate a combined point source map.
+
+        Returns
+        -------
+        sky : np.ndarray[nfreq, npix]
+            Map of brightness temperature on the sky (in K).
+        """
+        return self.getpolsky()[:, 0]
+
+    def getpolsky(self):
+        """Simulate a combined point source map.
+
+        Returns
+        -------
+        sky : np.ndarray[nfreq, 4, npix]
+            Map of brightness temperature on the sky (in K).
+        """
+        obj_unresolved = self._UnresolvedBackground.like_map(self)
+        obj_random = self._RandomResolved.like_map(self)
+
+        obj_fluxcat = FluxCatPointSources.like_map(self)
+        obj_fluxcat.flux_min = 4.0
+        obj_fluxcat.flux_max = self.flux_max
+        obj_fluxcat.catalog_file = self.catalog_file
+
+        if self.flux_max is not None and self.flux_max < obj_random.flux_max:
+            obj_random.flux_max = self.flux_max
+
+        ps_all = obj_unresolved.getpolsky()
+        ps_all += obj_random.getpolsky()
+        ps_all += obj_fluxcat.getpolsky()
+
+        self._used_collections = obj_fluxcat._used_collections
+        return ps_all
+
+
+class FluxCatPointSources(maps.Map3d):
+    r"""Creates maps of point sources from the fluxcat catalog.
+
+    Uses the fluxcat catalog to look up source positions (RA, DEC) and predict
+    their flux densities at each frequency. Sources are optionally filtered by
+    their predicted flux at 600 MHz. No polarisation is included (Q = U = V = 0).
+
+    After calling :meth:`getpolsky`, the attribute ``_used_collections`` holds
+    the list of fluxcat collection names that contributed to the map, which is
+    also written into the output HDF5 file as ``index_map/catalog``.
+
+    Attributes
+    ----------
+    flux_min : float or None
+        Minimum flux (in Jy at 600 MHz) of sources to include. Default is 1.0 Jy.
+        Set to None for no lower limit.
+    flux_max : float or None
+        Maximum flux (in Jy at 600 MHz) of sources to include. Default is None
+        (no upper limit).
+    catalog_file : str or None
+        Path to an additional JSON catalog file to load into fluxcat before
+        generating the map. Default is None.
+    """
+
+    flux_min = 1.0
+    flux_max = None
+    catalog_file = None
+
+    _ref_freq = 600.0  # MHz, reference frequency for flux filtering
+
+    def getsky(self):
+        """Simulate a map of point sources from the fluxcat catalog.
+
+        Returns
+        -------
+        sky : np.ndarray[nfreq, npix]
+            Map of brightness temperature on the sky (in K).
+        """
+        return self.getpolsky()[:, 0]
+
+    def getpolsky(self):
+        """Simulate a map of point sources from the fluxcat catalog.
+
+        Stokes Q, U and V are set to zero since fluxcat has no polarisation
+        information.
+
+        Returns
+        -------
+        sky : np.ndarray[nfreq, 4, npix]
+            Map of brightness temperature on the sky (in K).
+        """
+        from fluxcat import FluxCatalog
+
+        if self.catalog_file is not None:
+            FluxCatalog.load(self.catalog_file, overwrite=1)
+
+        freq = self.nu_pixels
+        sky = np.zeros((len(freq), 4, 12 * self.nside**2), dtype=np.float64)
+        pxarea = healpy.nside2pixarea(self.nside)
+
+        for name in FluxCatalog:
+            src = FluxCatalog.get(name)
+            flux_ref = src.predict_flux(self._ref_freq)
+
+            if self.flux_min is not None and flux_ref < self.flux_min:
+                continue
+            if self.flux_max is not None and flux_ref > self.flux_max:
+                continue
+
+            ix = healpy.ang2pix(self.nside, src.ra, src.dec, lonlat=True)
+            sky[:, 0, ix] += src.predict_flux(freq)
+
+        sky = (
+            sky
+            * 1e-26
+            * constants.c**2
+            / (
+                2
+                * constants.k_B
+                * freq[:, np.newaxis, np.newaxis] ** 2
+                * 1e12
+                * pxarea
+            )
+        )
+
+        self._used_collections = [name for name, _ in FluxCatalog.loaded_collections()]
+        return sky
+
+
+class SingleFluxCatSource(maps.Map3d):
+    r"""Creates a map with a single point source from the fluxcat catalog.
+
+    Looks up the source position (RA, DEC) and flux density from fluxcat and
+    places it in a HEALPix map at each frequency. No polarisation is included
+    (Q = U = V = 0).
+
+    After calling :meth:`getpolsky`, the attribute ``_used_collections`` holds
+    the list of fluxcat collection names that contributed to the map, which is
+    also written into the output HDF5 file as ``index_map/catalog``.
+
+    Attributes
+    ----------
+    source_name : str
+        Name of the source in the fluxcat catalog (e.g. ``'CYG_A'``).
+        Default is ``'CYG_A'``.
+    catalog_file : str or None
+        Path to an additional JSON catalog file to load into fluxcat before
+        generating the map. Default is None.
+    """
+
+    source_name = "CYG_A"
+    catalog_file = None
+
+    def getsky(self):
+        """Simulate a map with a single point source.
+
+        Returns
+        -------
+        sky : np.ndarray[nfreq, npix]
+            Map of brightness temperature on the sky (in K).
+        """
+        return self.getpolsky()[:, 0]
+
+    def getpolsky(self):
+        """Simulate a map with a single point source.
+
+        Stokes Q, U and V are set to zero.
+
+        Returns
+        -------
+        sky : np.ndarray[nfreq, 4, npix]
+            Map of brightness temperature on the sky (in K).
+        """
+        from fluxcat import FluxCatalog
+
+        if self.catalog_file is not None:
+            FluxCatalog.load(self.catalog_file, overwrite=1)
+
+        src = FluxCatalog.get(self.source_name)
+        freq = self.nu_pixels
+        sky = np.zeros((len(freq), 4, 12 * self.nside**2), dtype=np.float64)
+        pxarea = healpy.nside2pixarea(self.nside)
+
+        ix = healpy.ang2pix(self.nside, src.ra, src.dec, lonlat=True)
+        sky[:, 0, ix] = src.predict_flux(freq)
+
+        sky = (
+            sky
+            * 1e-26
+            * constants.c**2
+            / (
+                2
+                * constants.k_B
+                * freq[:, np.newaxis, np.newaxis] ** 2
+                * 1e12
+                * pxarea
+            )
+        )
+
+        self._used_collections = [name for name, _ in FluxCatalog.loaded_collections()]
+        return sky
+
+
+class FluxCatCatalogMap(maps.Map3d):
+    r"""Creates a HEALPix map of all sources in the loaded fluxcat catalog.
+
+    Maps every source in the fluxcat catalog to a HEALPix sky map without any
+    flux filtering. This is useful for generating a complete catalog-based sky
+    model. No polarisation is included (Q = U = V = 0).
+
+    After calling :meth:`getpolsky`, the attribute ``_used_collections`` holds
+    the list of fluxcat collection names that contributed to the map, which is
+    also written into the output HDF5 file as ``index_map/catalog``.
+
+    Attributes
+    ----------
+    catalog_file : str or None
+        Path to an additional JSON catalog file to load into fluxcat before
+        generating the map. Default is None.
+    """
+
+    catalog_file = None
+
+    def getsky(self):
+        """Simulate a map of all sources in the fluxcat catalog.
+
+        Returns
+        -------
+        sky : np.ndarray[nfreq, npix]
+            Map of brightness temperature on the sky (in K).
+        """
+        return self.getpolsky()[:, 0]
+
+    def getpolsky(self):
+        """Simulate a map of all sources in the fluxcat catalog.
+
+        Stokes Q, U and V are set to zero.
+
+        Returns
+        -------
+        sky : np.ndarray[nfreq, 4, npix]
+            Map of brightness temperature on the sky (in K).
+        """
+        from fluxcat import FluxCatalog
+
+        if self.catalog_file is not None:
+            FluxCatalog.load(self.catalog_file, overwrite=1)
+
+        freq = self.nu_pixels
+        sky = np.zeros((len(freq), 4, 12 * self.nside**2), dtype=np.float64)
+        pxarea = healpy.nside2pixarea(self.nside)
+
+        for name in FluxCatalog:
+            src = FluxCatalog.get(name)
+            ix = healpy.ang2pix(self.nside, src.ra, src.dec, lonlat=True)
+            sky[:, 0, ix] += src.predict_flux(freq)
+
+        sky = (
+            sky
+            * 1e-26
+            * constants.c**2
+            / (
+                2
+                * constants.k_B
+                * freq[:, np.newaxis, np.newaxis] ** 2
+                * 1e12
+                * pxarea
+            )
+        )
+
+        self._used_collections = [name for name, _ in FluxCatalog.loaded_collections()]
+        return sky

--- a/cora/scripts/makesky.py
+++ b/cora/scripts/makesky.py
@@ -270,8 +270,8 @@ def foreground_fluxcat(fstate, nside, pol, filename, maxflux, catalog_file):
     synthetic DiMatteo population and unresolved Gaussian background are used
     as before. The requested map must have more than two frequencies.
 
-    The fluxcat collections used are recorded in the output file under
-    index_map/catalog.
+    The fluxcat collections used are recorded in the output file as the
+    ``catalog`` file attribute.
     """
     if fstate.frequencies.shape[0] < 2:
         print("Number of frequencies must be more than two.")
@@ -463,7 +463,7 @@ def singlesource(fstate, nside, pol, filename, ra, dec):
     write_map(filename, map_, fstate.frequencies, fstate.freq_width, pol != "none")
 
 
-@cli.command("fluxcatpoints")
+@cli.command("pointsource-fluxcat")
 @map_options
 @click.option(
     "--flux-min",
@@ -483,13 +483,13 @@ def singlesource(fstate, nside, pol, filename, ra, dec):
     type=click.Path(exists=True),
     help="Path to an additional JSON catalog file to load into fluxcat.",
 )
-def fluxcatpoints(fstate, nside, pol, filename, flux_min, flux_max, catalog_file):
+def pointsource_fluxcat(fstate, nside, pol, filename, flux_min, flux_max, catalog_file):
     """Generate a point source map from the fluxcat catalog.
 
     Uses the fluxcat catalog to look up source positions and predict flux
     densities at each frequency. Sources outside the flux range are excluded.
     No polarisation is included (Q = U = V = 0). The fluxcat collections used
-    are recorded in the output file under index_map/catalog.
+    are recorded in the output file as the ``catalog`` file attribute.
     """
     from cora.foreground import pointsource
 
@@ -531,8 +531,8 @@ def singlesource_fluxcat(fstate, nside, pol, filename, source_name, catalog_file
 
     Looks up the source position and flux density in the fluxcat catalog and
     places it in a HEALPix map. No polarisation is included (Q = U = V = 0).
-    The fluxcat collections used are recorded in the output file under
-    index_map/catalog.
+    The fluxcat collections used are recorded in the output file as the
+    ``catalog`` file attribute.
     """
     from cora.foreground import pointsource
 
@@ -554,7 +554,7 @@ def singlesource_fluxcat(fstate, nside, pol, filename, source_name, catalog_file
     )
 
 
-@cli.command("fluxcatcatalog")
+@cli.command("catalog-fluxcat")
 @map_options
 @click.option(
     "--catalog-file",
@@ -562,12 +562,13 @@ def singlesource_fluxcat(fstate, nside, pol, filename, source_name, catalog_file
     type=click.Path(exists=True),
     help="Path to an additional JSON catalog file to load into fluxcat.",
 )
-def fluxcatcatalog(fstate, nside, pol, filename, catalog_file):
+def catalog_fluxcat(fstate, nside, pol, filename, catalog_file):
     """Generate a map of all sources in the loaded fluxcat catalog.
 
     Maps every source in the fluxcat catalog to a HEALPix sky map without any
     flux filtering. No polarisation is included (Q = U = V = 0). The fluxcat
-    collections used are recorded in the output file under index_map/catalog.
+    collections used are recorded in the output file as the ``catalog`` file
+    attribute.
     """
     from cora.foreground import pointsource
 
@@ -629,6 +630,4 @@ def write_map(filename, data, freq, fwidth=None, include_pol=True, catalog_info=
         dset.attrs["__memh5_distributed_dset"] = False
 
         if catalog_info is not None:
-            catalog_arr = np.array(catalog_info)
-            dset = f.create_dataset("index_map/catalog", data=catalog_arr.astype(dt))
-            dset.attrs["__memh5_distributed_dset"] = False
+            f.attrs["catalog"] = np.array(catalog_info).astype(dt)

--- a/cora/scripts/makesky.py
+++ b/cora/scripts/makesky.py
@@ -248,6 +248,60 @@ def foreground(fstate, nside, pol, filename, maxflux):
     write_map(filename, cs, gal.frequencies, fstate.freq_width, pol != "none")
 
 
+@cli.command("foreground-fluxcat")
+@map_options
+@click.option(
+    "--maxflux",
+    default=1e6,
+    type=float,
+    help="Maximum flux of included point sources (in Jy). Default is 1 MJy.",
+)
+@click.option(
+    "--catalog-file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Path to an additional JSON catalog file to load into fluxcat.",
+)
+def foreground_fluxcat(fstate, nside, pol, filename, maxflux, catalog_file):
+    """Generate a full foreground sky map using fluxcat for bright point sources.
+
+    Same structure as the foreground command but replaces the old real-source
+    catalog with fluxcat above 4 Jy (at 600 MHz). Below that threshold the
+    synthetic DiMatteo population and unresolved Gaussian background are used
+    as before. The requested map must have more than two frequencies.
+
+    The fluxcat collections used are recorded in the output file under
+    index_map/catalog.
+    """
+    if fstate.frequencies.shape[0] < 2:
+        print("Number of frequencies must be more than two.")
+        return
+
+    from cora.foreground import galaxy, pointsource
+
+    gal = galaxy.ConstrainedGalaxy()
+    gal.nside = nside
+    gal.frequencies = fstate.frequencies
+
+    cs = gal.getpolsky() if pol == "full" else gal.getsky()
+
+    ps = pointsource.CombinedFluxCatPointSources.like_map(gal)
+    ps.flux_max = maxflux
+    if catalog_file is not None:
+        ps.catalog_file = catalog_file
+
+    cs = cs + (ps.getpolsky() if pol == "full" else ps.getsky())
+
+    write_map(
+        filename,
+        cs,
+        gal.frequencies,
+        fstate.freq_width,
+        pol != "none",
+        catalog_info=ps._used_collections,
+    )
+
+
 @cli.command()
 @map_options
 @click.option("--spectral-index", default="md", type=click.Choice(["md", "gsm", "gd"]))
@@ -409,7 +463,132 @@ def singlesource(fstate, nside, pol, filename, ra, dec):
     write_map(filename, map_, fstate.frequencies, fstate.freq_width, pol != "none")
 
 
-def write_map(filename, data, freq, fwidth=None, include_pol=True):
+@cli.command("fluxcatpoints")
+@map_options
+@click.option(
+    "--flux-min",
+    default=1.0,
+    type=float,
+    help="Minimum flux (in Jy at 600 MHz) of sources to include. Default is 1.0 Jy.",
+)
+@click.option(
+    "--flux-max",
+    default=None,
+    type=float,
+    help="Maximum flux (in Jy at 600 MHz) of sources to include. Default is no upper limit.",
+)
+@click.option(
+    "--catalog-file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Path to an additional JSON catalog file to load into fluxcat.",
+)
+def fluxcatpoints(fstate, nside, pol, filename, flux_min, flux_max, catalog_file):
+    """Generate a point source map from the fluxcat catalog.
+
+    Uses the fluxcat catalog to look up source positions and predict flux
+    densities at each frequency. Sources outside the flux range are excluded.
+    No polarisation is included (Q = U = V = 0). The fluxcat collections used
+    are recorded in the output file under index_map/catalog.
+    """
+    from cora.foreground import pointsource
+
+    ps = pointsource.FluxCatPointSources()
+    ps.nside = nside
+    ps.frequencies = fstate.frequencies
+    ps.flux_min = flux_min
+    ps.flux_max = flux_max
+    if catalog_file is not None:
+        ps.catalog_file = catalog_file
+
+    cs = ps.getpolsky() if pol == "full" else ps.getsky()
+    write_map(
+        filename,
+        cs,
+        ps.frequencies,
+        fstate.freq_width,
+        pol != "none",
+        catalog_info=ps._used_collections,
+    )
+
+
+@cli.command("singlesource-fluxcat")
+@map_options
+@click.option(
+    "--source-name",
+    default="CYG_A",
+    type=str,
+    help="Name of the source in the fluxcat catalog. Default is CYG_A.",
+)
+@click.option(
+    "--catalog-file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Path to an additional JSON catalog file to load into fluxcat.",
+)
+def singlesource_fluxcat(fstate, nside, pol, filename, source_name, catalog_file):
+    """Generate a map with a single source from the fluxcat catalog.
+
+    Looks up the source position and flux density in the fluxcat catalog and
+    places it in a HEALPix map. No polarisation is included (Q = U = V = 0).
+    The fluxcat collections used are recorded in the output file under
+    index_map/catalog.
+    """
+    from cora.foreground import pointsource
+
+    ps = pointsource.SingleFluxCatSource()
+    ps.nside = nside
+    ps.frequencies = fstate.frequencies
+    ps.source_name = source_name
+    if catalog_file is not None:
+        ps.catalog_file = catalog_file
+
+    cs = ps.getpolsky() if pol == "full" else ps.getsky()
+    write_map(
+        filename,
+        cs,
+        ps.frequencies,
+        fstate.freq_width,
+        pol != "none",
+        catalog_info=ps._used_collections,
+    )
+
+
+@cli.command("fluxcatcatalog")
+@map_options
+@click.option(
+    "--catalog-file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Path to an additional JSON catalog file to load into fluxcat.",
+)
+def fluxcatcatalog(fstate, nside, pol, filename, catalog_file):
+    """Generate a map of all sources in the loaded fluxcat catalog.
+
+    Maps every source in the fluxcat catalog to a HEALPix sky map without any
+    flux filtering. No polarisation is included (Q = U = V = 0). The fluxcat
+    collections used are recorded in the output file under index_map/catalog.
+    """
+    from cora.foreground import pointsource
+
+    ps = pointsource.FluxCatCatalogMap()
+    ps.nside = nside
+    ps.frequencies = fstate.frequencies
+    if catalog_file is not None:
+        ps.catalog_file = catalog_file
+
+    cs = ps.getpolsky() if pol == "full" else ps.getsky()
+    write_map(
+        filename,
+        cs,
+        ps.frequencies,
+        fstate.freq_width,
+        pol != "none",
+        catalog_info=ps._used_collections,
+    )
+
+
+def write_map(filename, data, freq, fwidth=None, include_pol=True, catalog_info=None):
     # Write out the map into an HDF5 file.
 
     import h5py
@@ -448,3 +627,8 @@ def write_map(filename, data, freq, fwidth=None, include_pol=True):
         dset.attrs["__memh5_distributed_dset"] = False
         dset = f.create_dataset("index_map/pixel", data=np.arange(data.shape[2]))
         dset.attrs["__memh5_distributed_dset"] = False
+
+        if catalog_info is not None:
+            catalog_arr = np.array(catalog_info)
+            dset = f.create_dataset("index_map/catalog", data=catalog_arr.astype(dt))
+            dset.attrs["__memh5_distributed_dset"] = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dynamic = ["readme", "version"]
 requires-python = ">=3.10"
 dependencies = [
     "caput[complete] @ git+https://github.com/radiocosmology/caput.git",
+    "fluxcat @ git+https://github.com/radiocosmology/fluxcat.git",
     "click",
     "cython",
     "h5py",


### PR DESCRIPTION
Add four new classes to `cora.foreground.pointsource` and corresponding commands to `cora-makesky` for generating sky maps from the `fluxcat` catalog. This is needed for `EigenCalibration` too, as Eigen calibration uses `fluxcat` point source catalog position and flux for calibration. 

- `FluxCatPointSources`: like `RealPointSources` but driven by fluxcat, with optional flux_min/flux_max filtering at 600 MHz.
- `SingleFluxCatSource`: single named source (e.g. CYG_A) looked up from fluxcat, placed in a HEALPix map at each frequency.
- `FluxCatCatalogMap`: all sources in the loaded `fluxcat` catalog, no flux filtering.
- `CombinedFluxCatPointSources`: same three-layer structure as `CombinedPointSources` (Gaussian unresolved + DiMatteo synthetic population + real resolved) but replaces `RealPointSources` with `FluxCatPointSources` above 4 Jy at 600 MHz.

All four classes record which `fluxcat` collections were used in `index_map/catalog` in the output HDF5 file for tracking which catalog is being used.

New makesky commands: `pointsource-fluxcat`, `singlesource-fluxcat`, `catalog-fluxcat`, `foreground-fluxcat`.